### PR TITLE
feat: Fix auto-abort when running commands via the `spectre-cli` container

### DIFF
--- a/cli/src/spectre_cli/commands/_utils.py
+++ b/cli/src/spectre_cli/commands/_utils.py
@@ -30,7 +30,7 @@ def safe_request(
     json: Optional[dict] = None,
     params: Optional[dict] = None,
     require_confirmation: bool = False,
-    suppress_confirmation: bool = False
+    non_interactive: bool = True
 ) -> dict:
     """Send a request to the `spectre-server` and handle jsend-style responses.
 
@@ -42,7 +42,7 @@ def safe_request(
     :param suppress_confirmation: If True, ignore the `require_confirmation` flag, and continue with the request.
     :return: Parsed JSON response as a dictionary.
     """
-    if require_confirmation and not suppress_confirmation:
+    if require_confirmation and not non_interactive:
         confirm_with_user()
         
     if route_url.startswith("/"):

--- a/cli/src/spectre_cli/commands/_utils.py
+++ b/cli/src/spectre_cli/commands/_utils.py
@@ -30,7 +30,7 @@ def safe_request(
     json: Optional[dict] = None,
     params: Optional[dict] = None,
     require_confirmation: bool = False,
-    non_interactive: bool = True
+    non_interactive: bool = False
 ) -> dict:
     """Send a request to the `spectre-server` and handle jsend-style responses.
 

--- a/cli/src/spectre_cli/commands/delete.py
+++ b/cli/src/spectre_cli/commands/delete.py
@@ -32,9 +32,9 @@ def logs(
                       "--day", 
                       "-d", 
                       help="Delete  logs under this numeric day."),
-    suppress_confirmation: bool = Option(False, 
-                                         "--suppress-confirmation", 
-                                         help="Suppress any user confirmation.")
+    non_interactive: bool = Option(False, 
+                                  "--non-interactive", 
+                                  help="Suppress any interactive prompts.")
     
 ) -> None:
     params = {
@@ -44,7 +44,7 @@ def logs(
                               "DELETE", 
                               params=params,
                               require_confirmation=True,
-                              suppress_confirmation=suppress_confirmation)
+                              non_interactive=non_interactive)
     endpoints = jsend_dict["data"]
     secho_stale_resources(endpoints)
     raise Exit()
@@ -74,9 +74,9 @@ def batch_files(
                       "--day", 
                       "-d", 
                       help="Delete all batch files under this numeric day."),
-    suppress_confirmation: bool = Option(False, 
-                                         "--suppress-confirmation", 
-                                         help="Suppress any user confirmation.")
+    non_interactive: bool = Option(False, 
+                                   "--non-interactive", 
+                                   help="Suppress any interactive prompts.")
 ) -> None:
     params = {
         "extension": extensions,
@@ -86,7 +86,7 @@ def batch_files(
                               "DELETE",
                               params = params,
                               require_confirmation=True,
-                              suppress_confirmation=suppress_confirmation)
+                              non_interactive=non_interactive)
     endpoints = jsend_dict["data"]
     secho_stale_resources(endpoints)
     raise Exit()
@@ -103,9 +103,9 @@ def capture_config(
     file_name: str = Option(None,
                             "-f",
                             help="The file name of the capture config."),
-    suppress_confirmation: bool = Option(False, 
-                         "--suppress-confirmation", 
-                         help="Suppress any user confirmation.")
+    non_interactive: bool = Option(False, 
+                                  "--non-interactive", 
+                                  help="Suppress any interactive prompts.")
 ) -> None:
     
                                                                            
@@ -114,7 +114,7 @@ def capture_config(
     jsend_dict = safe_request(f"spectre-data/configs/{tag}.json", 
                               "DELETE",
                               require_confirmation=True,
-                              suppress_confirmation=suppress_confirmation)
+                              non_interactive=non_interactive)
     endpoint = jsend_dict["data"]
     secho_stale_resource(endpoint)
     raise Exit()


### PR DESCRIPTION
Update the flag name from `--suppress-confirmation` to the more descriptive `--non-interactive`