### PR TITLE
feat: User-configurable `max_restarts`

### DIFF
--- a/backend/src/spectre_server/routes/jobs.py
+++ b/backend/src/spectre_server/routes/jobs.py
@@ -20,7 +20,8 @@ def capture() -> str:
     minutes = json.get("minutes")
     hours = json.get("hours")
     force_restart = json.get("force_restart")
-    return jobs.capture(tag, seconds, minutes, hours, force_restart)
+    max_restarts = json.get("max_restarts")
+    return jobs.capture(tag, seconds, minutes, hours, force_restart, max_restarts)
 
 
 @jobs_blueprint.route("/session", methods=["POST"])
@@ -32,4 +33,5 @@ def session() -> str:
     minutes = json.get("minutes")
     hours = json.get("hours")
     force_restart = json.get("force_restart")
-    return jobs.session(tag, seconds, minutes, hours, force_restart)
+    max_restarts = json.get("max_restarts")
+    return jobs.session(tag, seconds, minutes, hours, force_restart, max_restarts)

--- a/backend/src/spectre_server/services/jobs.py
+++ b/backend/src/spectre_server/services/jobs.py
@@ -44,6 +44,7 @@ def capture(
     minutes: int = 0,
     hours: int = 0,
     force_restart: bool = False,
+    max_restarts: int = 5
 ) -> str:
     """Start capturing data from an SDR in real time.
 
@@ -51,15 +52,16 @@ def capture(
     :param seconds: The seconds component of the total runtime, defaults to 0
     :param minutes: The minutes component of the total runtime, defaults to 0
     :param hours: The hours component of the total runtime, defaults to 0
-    :param force_restart: If any worker encounters an error at runtime, force all
-    the workers to restart their processes. Defaults to False
+    :param force_restart: Whether to restart all workers if one dies unexpectedly.
+    :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers. 
+    Only applies when force_restart is True. Defaults to 5.
     :return: A string indicating the job has completed.
     """
     # Trailing commas are required so that the bracket terms are interpreted as tuples, not a grouping.
     capture_worker = jobs.make_worker("capture_worker", _start_capture, (tag,))
     workers = [capture_worker]
     total_runtime = _calculate_total_runtime(seconds, minutes, hours)
-    jobs.start_job(workers, total_runtime, force_restart)
+    jobs.start_job(workers, total_runtime, force_restart, max_restarts)
     return "Capture complete."
 
 
@@ -70,6 +72,7 @@ def session(
     minutes: int = 0,
     hours: int = 0,
     force_restart: bool = False,
+    max_restarts: int = 5
 ) -> str:
     """Start capturing data from an SDR, and post-process the data in real time into spectrograms.
 
@@ -77,8 +80,10 @@ def session(
     :param seconds: The seconds component of the total runtime, defaults to 0
     :param minutes: The minutes component of the total runtime, defaults to 0
     :param hours: The hours component of the total runtime, defaults to 0
-    :param force_restart: If any worker encounters an error at runtime, force all
-    the workers to restart their processes. Defaults to False
+    :param force_restart: Whether to restart all workers if one dies unexpectedly.
+    :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers. 
+    Only applies when force_restart is True. Defaults to 5.
+    :return: A string indicating the job has completed.
     """
     # Trailing commas are required so that the bracket terms are interpreted as tuples, not a grouping.
     post_processing_worker = jobs.make_worker(
@@ -89,5 +94,5 @@ def session(
     # start the post processing worker first, so that it sees the first files opened by the capture worker.
     workers = [post_processing_worker, capture_worker]
     total_runtime = _calculate_total_runtime(seconds, minutes, hours)
-    jobs.start_job(workers, total_runtime, force_restart)
+    jobs.start_job(workers, total_runtime, force_restart, max_restarts)
     return "Session complete."

--- a/backend/src/spectre_server/services/jobs.py
+++ b/backend/src/spectre_server/services/jobs.py
@@ -44,7 +44,7 @@ def capture(
     minutes: int = 0,
     hours: int = 0,
     force_restart: bool = False,
-    max_restarts: int = 5
+    max_restarts: int = 5,
 ) -> str:
     """Start capturing data from an SDR in real time.
 
@@ -53,7 +53,7 @@ def capture(
     :param minutes: The minutes component of the total runtime, defaults to 0
     :param hours: The hours component of the total runtime, defaults to 0
     :param force_restart: Whether to restart all workers if one dies unexpectedly.
-    :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers. 
+    :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers.
     Only applies when force_restart is True. Defaults to 5.
     :return: A string indicating the job has completed.
     """
@@ -72,7 +72,7 @@ def session(
     minutes: int = 0,
     hours: int = 0,
     force_restart: bool = False,
-    max_restarts: int = 5
+    max_restarts: int = 5,
 ) -> str:
     """Start capturing data from an SDR, and post-process the data in real time into spectrograms.
 
@@ -81,7 +81,7 @@ def session(
     :param minutes: The minutes component of the total runtime, defaults to 0
     :param hours: The hours component of the total runtime, defaults to 0
     :param force_restart: Whether to restart all workers if one dies unexpectedly.
-    :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers. 
+    :param max_restarts: Maximum number of times workers can be restarted before giving up and killing all workers.
     Only applies when force_restart is True. Defaults to 5.
     :return: A string indicating the job has completed.
     """

--- a/cli/src/spectre_cli/commands/start.py
+++ b/cli/src/spectre_cli/commands/start.py
@@ -13,29 +13,35 @@ _DEFAULT_DURATION = 0
 _DEFAULT_MAX_RESTARTS = 5
 _DEFAULT_FORCE_RESTART = False
 
+
 @start_typer.command(help="Capture data from an SDR in real time.")
 def capture(
     tag: str = typer.Option(..., "--tag", "-t", help="The capture config tag."),
     seconds: int = typer.Option(
-        _DEFAULT_DURATION, "--seconds", help="The seconds component of the capture duration."
+        _DEFAULT_DURATION,
+        "--seconds",
+        help="The seconds component of the capture duration.",
     ),
     minutes: int = typer.Option(
-        _DEFAULT_DURATION, "--minutes", help="The minutes component of the capture duration."
+        _DEFAULT_DURATION,
+        "--minutes",
+        help="The minutes component of the capture duration.",
     ),
     hours: int = typer.Option(
-        _DEFAULT_DURATION, "--hours", help="The hours component of the capture duration."
+        _DEFAULT_DURATION,
+        "--hours",
+        help="The hours component of the capture duration.",
     ),
     force_restart: bool = typer.Option(
         _DEFAULT_FORCE_RESTART,
         "--force-restart",
-        help="Whether to restart all workers if one dies unexpectedly."
-        "and restart.",
+        help="Whether to restart all workers if one dies unexpectedly." "and restart.",
     ),
     max_restarts: int = typer.Option(
         _DEFAULT_MAX_RESTARTS,
         "--max-restarts",
         help="Maximum number of times workers can be restarted before giving up and killing all workers. ",
-    )
+    ),
 ) -> None:
     json = {
         "tag": tag,
@@ -43,7 +49,7 @@ def capture(
         "minutes": minutes,
         "hours": hours,
         "force_restart": force_restart,
-        "max_restarts": max_restarts
+        "max_restarts": max_restarts,
     }
     _ = safe_request("jobs/capture", "POST", json=json)
     typer.secho(f"Capture completed sucessfully for tag '{tag}'")
@@ -56,25 +62,30 @@ def capture(
 def session(
     tag: str = typer.Option(..., "--tag", "-t", help="The capture config tag."),
     seconds: int = typer.Option(
-        _DEFAULT_DURATION, "--seconds", help="The seconds component of the session duration."
+        _DEFAULT_DURATION,
+        "--seconds",
+        help="The seconds component of the session duration.",
     ),
     minutes: int = typer.Option(
-        _DEFAULT_DURATION, "--minutes", help="The minutes component of the session duration."
+        _DEFAULT_DURATION,
+        "--minutes",
+        help="The minutes component of the session duration.",
     ),
     hours: int = typer.Option(
-        _DEFAULT_DURATION, "--hours", help="The hours component of the session duration."
+        _DEFAULT_DURATION,
+        "--hours",
+        help="The hours component of the session duration.",
     ),
     force_restart: bool = typer.Option(
         _DEFAULT_FORCE_RESTART,
         "--force-restart",
-        help="Whether to restart all workers if one dies unexpectedly."
-        "and restart.",
+        help="Whether to restart all workers if one dies unexpectedly." "and restart.",
     ),
     max_restarts: int = typer.Option(
         _DEFAULT_MAX_RESTARTS,
         "--max-restarts",
         help="Maximum number of times workers can be restarted before giving up and killing all workers.",
-    )
+    ),
 ) -> None:
     json = {
         "tag": tag,
@@ -82,7 +93,7 @@ def session(
         "minutes": minutes,
         "hours": hours,
         "force_restart": force_restart,
-        "max_restarts": max_restarts
+        "max_restarts": max_restarts,
     }
     _ = safe_request("jobs/session", "POST", json=json)
     typer.secho(f"Session completed sucessfully for tag '{tag}'")

--- a/cli/src/spectre_cli/commands/start.py
+++ b/cli/src/spectre_cli/commands/start.py
@@ -9,25 +9,33 @@ from ._utils import safe_request
 
 start_typer = typer.Typer(help="Start a job.")
 
+_DEFAULT_DURATION = 0
+_DEFAULT_MAX_RESTARTS = 5
+_DEFAULT_FORCE_RESTART = False
 
 @start_typer.command(help="Capture data from an SDR in real time.")
 def capture(
     tag: str = typer.Option(..., "--tag", "-t", help="The capture config tag."),
     seconds: int = typer.Option(
-        0, "--seconds", help="The seconds component of the capture duration."
+        _DEFAULT_DURATION, "--seconds", help="The seconds component of the capture duration."
     ),
     minutes: int = typer.Option(
-        0, "--minutes", help="The minutes component of the capture duration."
+        _DEFAULT_DURATION, "--minutes", help="The minutes component of the capture duration."
     ),
     hours: int = typer.Option(
-        0, "--hours", help="The hours component of the capture duration."
+        _DEFAULT_DURATION, "--hours", help="The hours component of the capture duration."
     ),
     force_restart: bool = typer.Option(
-        False,
+        _DEFAULT_FORCE_RESTART,
         "--force-restart",
-        help="When a worker process stops unexpectedly, terminate all workers "
+        help="Whether to restart all workers if one dies unexpectedly."
         "and restart.",
     ),
+    max_restarts: int = typer.Option(
+        _DEFAULT_MAX_RESTARTS,
+        "--max-restarts",
+        help="Maximum number of times workers can be restarted before giving up and killing all workers. ",
+    )
 ) -> None:
     json = {
         "tag": tag,
@@ -35,6 +43,7 @@ def capture(
         "minutes": minutes,
         "hours": hours,
         "force_restart": force_restart,
+        "max_restarts": max_restarts
     }
     _ = safe_request("jobs/capture", "POST", json=json)
     typer.secho(f"Capture completed sucessfully for tag '{tag}'")
@@ -47,20 +56,25 @@ def capture(
 def session(
     tag: str = typer.Option(..., "--tag", "-t", help="The capture config tag."),
     seconds: int = typer.Option(
-        0, "--seconds", help="The seconds component of the session duration."
+        _DEFAULT_DURATION, "--seconds", help="The seconds component of the session duration."
     ),
     minutes: int = typer.Option(
-        0, "--minutes", help="The minutes component of the session duration."
+        _DEFAULT_DURATION, "--minutes", help="The minutes component of the session duration."
     ),
     hours: int = typer.Option(
-        0, "--hours", help="The hours component of the session duration."
+        _DEFAULT_DURATION, "--hours", help="The hours component of the session duration."
     ),
     force_restart: bool = typer.Option(
-        False,
+        _DEFAULT_FORCE_RESTART,
         "--force-restart",
-        help="When a worker process stops unexpectedly, terminate all workers "
+        help="Whether to restart all workers if one dies unexpectedly."
         "and restart.",
     ),
+    max_restarts: int = typer.Option(
+        _DEFAULT_MAX_RESTARTS,
+        "--max-restarts",
+        help="Maximum number of times workers can be restarted before giving up and killing all workers.",
+    )
 ) -> None:
     json = {
         "tag": tag,
@@ -68,6 +82,7 @@ def session(
         "minutes": minutes,
         "hours": hours,
         "force_restart": force_restart,
+        "max_restarts": max_restarts
     }
     _ = safe_request("jobs/session", "POST", json=json)
     typer.secho(f"Session completed sucessfully for tag '{tag}'")


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Allow the user to configure the number of times workers can be restarted during a job.

## Issue link
<!-- Add the link to the related issue(s) -->
n/a 

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [ ] My changes are covered by unit tests
- [ ] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
