### PR TITLE
feat: Add a CLI spinner during jobs

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -336,7 +336,7 @@ COPY gunicorn.conf.py /opt/spectre_server/
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>" \
-      version="0.0.24-alpha" \
+      version="0.1.0-alpha" \
       description="Docker image for running the `spectre-server`." \
       license="GPL-3.0-or-later"
 
@@ -408,7 +408,7 @@ CMD ["/app/cmd.sh"]
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>" \
-      version="0.0.24-alpha" \
+      version="0.1.0-alpha" \
       description="Docker image for  developing the `spectre-server`." \
       license="GPL-3.0-or-later"
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-server"
-version = "0.0.24-alpha"
+version = "0.1.0-alpha"
 authors = [
   { name = "Jimmy Fitzpatrick", email = "jcfitzpatrick12@gmail.com" }
 ]

--- a/backend/src/spectre_server/__init__.py
+++ b/backend/src/spectre_server/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "0.0.24-alpha"
+__version__ = "0.1.0-alpha"

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install .
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>" \
-      version="0.0.24-alpha" \
+      version="0.1.0-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 
@@ -57,7 +57,7 @@ USER appuser
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>" \
-      version="0.0.24-alpha" \
+      version="0.1.0-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "click<8.2.0",
     "typer-slim==0.13.1",
     "requests==2.31.0",
-    "pyyaml==6.0.2"
+    "pyyaml==6.0.2",
+    "yaspin==3.1.0"
 ]
 
 [project.optional-dependencies]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-cli"
-version = "0.0.24-alpha"
+version = "0.1.0-alpha"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jcfitzpatrick12@gmail.com" },
 ]

--- a/cli/src/spectre_cli/__init__.py
+++ b/cli/src/spectre_cli/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "0.0.24-alpha"
+__version__ = "0.1.0-alpha"

--- a/cli/src/spectre_cli/commands/start.py
+++ b/cli/src/spectre_cli/commands/start.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import typer
+from yaspin import yaspin
 
 from ._utils import safe_request
 
@@ -13,7 +14,7 @@ _DEFAULT_DURATION = 0
 _DEFAULT_MAX_RESTARTS = 5
 _DEFAULT_FORCE_RESTART = False
 _DEFAULT_SKIP_VALIDATION = False
-
+_IN_PROGRESS="In progress... "
 
 @start_typer.command(help="Capture data from an SDR in real time.")
 def capture(
@@ -58,8 +59,8 @@ def capture(
         "max_restarts": max_restarts,
         "validate": not skip_validation,
     }
-    _ = safe_request("jobs/capture", "POST", json=json)
-    typer.secho(f"Capture completed successfully for tag '{tag}'")
+    with yaspin(text=_IN_PROGRESS):
+        _ = safe_request("jobs/capture", "POST", json=json)
     raise typer.Exit()
 
 
@@ -108,6 +109,6 @@ def session(
         "max_restarts": max_restarts,
         "validate": not skip_validation,
     }
-    _ = safe_request("jobs/session", "POST", json=json)
-    typer.secho(f"Session completed successfully for tag '{tag}'")
+    with yaspin(text=_IN_PROGRESS):
+        _ = safe_request("jobs/session", "POST", json=json)
     raise typer.Exit()

--- a/cli/src/spectre_cli/commands/start.py
+++ b/cli/src/spectre_cli/commands/start.py
@@ -14,7 +14,8 @@ _DEFAULT_DURATION = 0
 _DEFAULT_MAX_RESTARTS = 5
 _DEFAULT_FORCE_RESTART = False
 _DEFAULT_SKIP_VALIDATION = False
-_IN_PROGRESS="In progress... "
+_IN_PROGRESS = "In progress... "
+
 
 @start_typer.command(help="Capture data from an SDR in real time.")
 def capture(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   spectre-server:
     container_name: spectre-server
-    image: jcfitzpatrick12/spectre-server:0.0.24-alpha
+    image: jcfitzpatrick12/spectre-server:0.1.0-alpha
     environment:
       - SPECTRE_GID=${SPECTRE_GID}
       - SPECTRE_BIND_HOST=${SPECTRE_BIND_HOST}
@@ -22,7 +22,7 @@ services:
 
   spectre-cli:
     container_name: spectre-cli
-    image: jcfitzpatrick12/spectre-cli:0.0.24-alpha
+    image: jcfitzpatrick12/spectre-cli:0.1.0-alpha
     environment:
       - SPECTRE_SERVER_HOST=${SPECTRE_SERVER_HOST}
       - SPECTRE_SERVER_PORT=${SPECTRE_SERVER_PORT}


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Adds a very simple spinning sprite during jobs using the third-party package `yaspin`. This only impacts `spectre start job` and `spectre start capture`. 

## Issue link
<!-- Add the link to the related issue(s) -->
n/a

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [ ] My changes are covered by unit tests
- [ ] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
