### PR TITLE
Bump spectre-core to v1.1.0

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -336,7 +336,7 @@ COPY gunicorn.conf.py /opt/spectre_server/
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>" \
-      version="1.0.0-alpha" \
+      version="1.0.1-alpha" \
       description="Docker image for running the `spectre-server`." \
       license="GPL-3.0-or-later"
 
@@ -408,7 +408,7 @@ CMD ["/app/cmd.sh"]
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>" \
-      version="1.0.0-alpha" \
+      version="1.0.1-alpha" \
       description="Docker image for  developing the `spectre-server`." \
       license="GPL-3.0-or-later"
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-server"
-version = "1.0.0-alpha"
+version = "1.0.1-alpha"
 authors = [
   { name = "Jimmy Fitzpatrick", email = "jcfitzpatrick12@gmail.com" }
 ]

--- a/backend/src/spectre_server/__init__.py
+++ b/backend/src/spectre_server/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "1.0.0-alpha"
+__version__ = "1.0.1-alpha"

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install .
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>" \
-      version="1.0.0-alpha" \
+      version="1.0.1-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 
@@ -57,7 +57,7 @@ USER appuser
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>" \
-      version="1.0.0-alpha" \
+      version="1.0.1-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-cli"
-version = "1.0.0-alpha"
+version = "1.0.1-alpha"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jcfitzpatrick12@gmail.com" },
 ]

--- a/cli/src/spectre_cli/__init__.py
+++ b/cli/src/spectre_cli/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "1.0.0-alpha"
+__version__ = "1.0.1-alpha"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   spectre-server:
     container_name: spectre-server
-    image: jcfitzpatrick12/spectre-server:1.0.0-alpha
+    image: jcfitzpatrick12/spectre-server:1.0.1-alpha
     environment:
       - SPECTRE_GID=${SPECTRE_GID}
       - SPECTRE_BIND_HOST=${SPECTRE_BIND_HOST}
@@ -22,7 +22,7 @@ services:
 
   spectre-cli:
     container_name: spectre-cli
-    image: jcfitzpatrick12/spectre-cli:1.0.0-alpha
+    image: jcfitzpatrick12/spectre-cli:1.0.1-alpha
     environment:
       - SPECTRE_SERVER_HOST=${SPECTRE_SERVER_HOST}
       - SPECTRE_SERVER_PORT=${SPECTRE_SERVER_PORT}


### PR DESCRIPTION
## What does this PR do?
This commit bumps the compat for spectre-core in backend/pyproject.toml from 1.0.0 to 1.1.0, following jcfitzpatrick12/spectre-core#53.

## Issue link
This is a follow-up to jcfitzpatrick12/spectre-core#53, which bumps the versioning of spectre-core from 1.0.0 to 1.1.0, following jcfitzpatrick12/spectre-core#52.

## Checklist before merging

- [x] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Each commit represents a single, coherent unit of work
- [x] My changes are covered by unit tests
- [x] Unit tests successfully run locally
- [x] I have formatted Python code with `black`
- [x] I have checked static type hinting with `mypy`
- [x] I have added/updated necessary documentation, if required
- [x] I have checked for and resolved any merge conflicts
- [x] I have performed a self-review of my code
