### PR TITLE
fix: Resolve Scipy import error

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -336,7 +336,7 @@ COPY gunicorn.conf.py /opt/spectre_server/
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>" \
-      version="1.0.1-alpha" \
+      version="1.0.2-alpha" \
       description="Docker image for running the `spectre-server`." \
       license="GPL-3.0-or-later"
 
@@ -408,7 +408,7 @@ CMD ["/app/cmd.sh"]
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>" \
-      version="1.0.1-alpha" \
+      version="1.0.2-alpha" \
       description="Docker image for  developing the `spectre-server`." \
       license="GPL-3.0-or-later"
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-server"
-version = "1.0.1-alpha"
+version = "1.0.2-alpha"
 authors = [
   { name = "Jimmy Fitzpatrick", email = "jcfitzpatrick12@gmail.com" }
 ]

--- a/backend/src/spectre_server/__init__.py
+++ b/backend/src/spectre_server/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "1.0.1-alpha"
+__version__ = "1.0.2-alpha"

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install .
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>" \
-      version="1.0.1-alpha" \
+      version="1.0.2-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 
@@ -57,7 +57,7 @@ USER appuser
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jcfitzpatrick12@gmail.com>" \
-      version="1.0.1-alpha" \
+      version="1.0.2-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-cli"
-version = "1.0.1-alpha"
+version = "1.0.2-alpha"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jcfitzpatrick12@gmail.com" },
 ]

--- a/cli/src/spectre_cli/__init__.py
+++ b/cli/src/spectre_cli/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "1.0.1-alpha"
+__version__ = "1.0.2-alpha"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   spectre-server:
     container_name: spectre-server
-    image: jcfitzpatrick12/spectre-server:1.0.1-alpha
+    image: jcfitzpatrick12/spectre-server:1.0.2-alpha
     environment:
       - SPECTRE_GID=${SPECTRE_GID}
       - SPECTRE_BIND_HOST=${SPECTRE_BIND_HOST}
@@ -22,7 +22,7 @@ services:
 
   spectre-cli:
     container_name: spectre-cli
-    image: jcfitzpatrick12/spectre-cli:1.0.1-alpha
+    image: jcfitzpatrick12/spectre-cli:1.0.2-alpha
     environment:
       - SPECTRE_SERVER_HOST=${SPECTRE_SERVER_HOST}
       - SPECTRE_SERVER_PORT=${SPECTRE_SERVER_PORT}


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Following the recent [PR](https://github.com/jcfitzpatrick12/spectre/pull/168), the new version of `spectre_core` contained an old unused Scipy import. This resulted in an error whereby the `spectre-server` could not start, since Scipy is no longer installed. I pushed a new version of `spectre_core` which should resolve this.

## Issue link
<!-- Add the link to the related issue(s) -->
[issue-167](https://github.com/jcfitzpatrick12/spectre/issues/167)

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [X] My changes are covered by unit tests
- [X] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X]] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
> n/a
