### PR TITLE
feat: Simplify command naming

### DIFF
--- a/backend/src/spectre_server/routes/jobs.py
+++ b/backend/src/spectre_server/routes/jobs.py
@@ -22,7 +22,7 @@ def capture() -> str:
     force_restart = json.get("force_restart")
     max_restarts = json.get("max_restarts")
     validate = json.get("validate")
-    return jobs.capture(
+    return jobs.signal(
         tag, seconds, minutes, hours, force_restart, max_restarts, validate
     )
 
@@ -38,6 +38,38 @@ def session() -> str:
     force_restart = json.get("force_restart")
     max_restarts = json.get("max_restarts")
     validate = json.get("validate")
-    return jobs.session(
+    return jobs.spectrograms(
+        tag, seconds, minutes, hours, force_restart, max_restarts, validate
+    )
+
+
+@jobs_blueprint.route("/signal", methods=["POST"])
+@jsendify_response
+def signal() -> str:
+    json = request.get_json()
+    tag = json.get("tag")
+    seconds = json.get("seconds")
+    minutes = json.get("minutes")
+    hours = json.get("hours")
+    force_restart = json.get("force_restart")
+    max_restarts = json.get("max_restarts")
+    validate = json.get("validate")
+    return jobs.signal(
+        tag, seconds, minutes, hours, force_restart, max_restarts, validate
+    )
+
+
+@jobs_blueprint.route("/spectrograms", methods=["POST"])
+@jsendify_response
+def spectrograms() -> str:
+    json = request.get_json()
+    tag = json.get("tag")
+    seconds = json.get("seconds")
+    minutes = json.get("minutes")
+    hours = json.get("hours")
+    force_restart = json.get("force_restart")
+    max_restarts = json.get("max_restarts")
+    validate = json.get("validate")
+    return jobs.spectrograms(
         tag, seconds, minutes, hours, force_restart, max_restarts, validate
     )

--- a/cli/src/spectre_cli/__main__.py
+++ b/cli/src/spectre_cli/__main__.py
@@ -11,6 +11,7 @@ from spectre_cli.commands.start import start_typer
 from spectre_cli.commands.update import update_typer
 from spectre_cli.commands.download import download_typer
 from spectre_cli.commands.test import test_typer
+from spectre_cli.commands.record import record_typer
 
 app = Typer(help="Spectre: Process, Explore and Capture Transient Radio Emissions")
 
@@ -21,3 +22,4 @@ app.add_typer(start_typer, name="start")
 app.add_typer(update_typer, name="update")
 app.add_typer(download_typer, name="download")
 app.add_typer(test_typer, name="test")
+app.add_typer(record_typer, name="record")

--- a/cli/src/spectre_cli/commands/_utils.py
+++ b/cli/src/spectre_cli/commands/_utils.py
@@ -78,8 +78,8 @@ def safe_request(
         )
 
 
-def get_capture_config_file_name(file_name: Optional[str], tag: Optional[str]) -> str:
-    """Given either a file name, or the tag, build the capture config file name.
+def get_config_file_name(file_name: Optional[str], tag: Optional[str]) -> str:
+    """Given either a file name, or the tag, build the config file name.
 
     Primarily used for input validation, where the user can specify either or via the CLI.
     """

--- a/cli/src/spectre_cli/commands/create.py
+++ b/cli/src/spectre_cli/commands/create.py
@@ -74,7 +74,7 @@ def config(
     force: bool = Option(
         False,
         "--force",
-        help="If specified, force the operation even if batch files exist with the same tag.",
+        help="If specified, force the operation even if files exist with the same tag.",
     ),
     skip_validation: bool = Option(
         False,
@@ -103,7 +103,7 @@ def plot(
         ...,
         "--tag",
         "-t",
-        help="The batch file tag. Specifying multiple tags yields a stacked plot over the same time frame.",
+        help="The file tag. Specifying multiple tags yields a stacked plot over the same time frame.",
     ),
     obs_date: str = Option(
         ...,

--- a/cli/src/spectre_cli/commands/create.py
+++ b/cli/src/spectre_cli/commands/create.py
@@ -6,12 +6,12 @@ from typer import Typer, Option, Exit
 from typing import List
 
 from ._secho_resources import secho_new_resource
-from ._utils import safe_request, get_capture_config_file_name
+from ._utils import safe_request, get_config_file_name
 
 create_typer = Typer(help="Create resources.")
 
 
-@create_typer.command(help="Create a capture config.")
+@create_typer.command(help="Create a capture config.", deprecated=True)
 def capture_config(
     receiver_name: str = Option(
         ..., "--receiver", "-r", help="The name of the receiver."
@@ -39,7 +39,50 @@ def capture_config(
         help="If specified, do not validate the parameters.",
     ),
 ) -> None:
-    file_name = get_capture_config_file_name(file_name, tag)
+    file_name = get_config_file_name(file_name, tag)
+
+    json = {
+        "receiver_name": receiver_name,
+        "receiver_mode": receiver_mode,
+        "string_parameters": params,
+        "force": force,
+        "validate": not skip_validation,
+    }
+    jsend_dict = safe_request(f"spectre-data/configs/{file_name}", "PUT", json=json)
+    endpoint = jsend_dict["data"]
+    secho_new_resource(endpoint)
+    raise Exit()
+
+
+@create_typer.command(help="Create a config.")
+def config(
+    receiver_name: str = Option(
+        ..., "--receiver", "-r", help="The name of the receiver."
+    ),
+    receiver_mode: str = Option(
+        ..., "--mode", "-m", help="The operating mode for the receiver."
+    ),
+    tag: str = Option(None, "--tag", "-t", help="The unique identifier."),
+    file_name: str = Option(None, "-f", help="The file name.", metavar="<tag>.json"),
+    params: List[str] = Option(
+        [],
+        "--param",
+        "-p",
+        help="Parameters as key-value pairs.",
+        metavar="<key>=<value>",
+    ),
+    force: bool = Option(
+        False,
+        "--force",
+        help="If specified, force the operation even if batch files exist with the same tag.",
+    ),
+    skip_validation: bool = Option(
+        False,
+        "--skip-validation",
+        help="If specified, do not validate the parameters.",
+    ),
+) -> None:
+    file_name = get_config_file_name(file_name, tag)
 
     json = {
         "receiver_name": receiver_name,

--- a/cli/src/spectre_cli/commands/delete.py
+++ b/cli/src/spectre_cli/commands/delete.py
@@ -63,7 +63,7 @@ def logs(
     raise Exit()
 
 
-@delete_typer.command(help="Delete batch files.")
+@delete_typer.command(help="Delete batch files.", deprecated=True)
 def batch_files(
     tags: list[str] = Option(
         [],
@@ -86,6 +86,59 @@ def batch_files(
     day: int = Option(
         None, "--day", "-d", help="Only delete batch files under this day."
     ),
+    non_interactive: bool = Option(
+        False, "--non-interactive", help="Suppress any interactive prompts."
+    ),
+    dry_run: bool = Option(
+        False,
+        "--dry-run",
+        help="Display which files would be deleted without actually deleting them.",
+    ),
+) -> None:
+    if dry_run:
+        non_interactive = True
+    params = {
+        "extension": extensions,
+        "tag": tags,
+        "dry_run": dry_run,
+        "year": year,
+        "month": month,
+        "day": day,
+    }
+    jsend_dict = safe_request(
+        f"spectre-data/batches",
+        "DELETE",
+        params=params,
+        require_confirmation=True,
+        non_interactive=non_interactive,
+    )
+    endpoints = jsend_dict["data"]
+    if not dry_run:
+        secho_stale_resources(endpoints)
+    else:
+        secho_existing_resources(endpoints)
+    raise Exit()
+
+
+@delete_typer.command(help="Delete files.")
+def files(
+    tags: list[str] = Option(
+        [],
+        "--tag",
+        "-t",
+        help="Delete all files with this tag. If not provided, nothing will be deleted.",
+    ),
+    extensions: list[str] = Option(
+        [],
+        "--extension",
+        "-e",
+        help="Delete all files with this file extension. If not provided, nothing will be deleted.",
+    ),
+    year: int = Option(None, "--year", "-y", help="Only delete files under this year."),
+    month: int = Option(
+        None, "--month", "-m", help="Only delete files under this month."
+    ),
+    day: int = Option(None, "--day", "-d", help="Only delete files under this day."),
     non_interactive: bool = Option(
         False, "--non-interactive", help="Suppress any interactive prompts."
     ),

--- a/cli/src/spectre_cli/commands/get.py
+++ b/cli/src/spectre_cli/commands/get.py
@@ -4,7 +4,7 @@
 
 from typer import Typer, Option, Exit, secho
 
-from ._utils import safe_request, get_capture_config_file_name
+from ._utils import safe_request, get_config_file_name
 from ._secho_resources import pprint_dict, secho_existing_resources
 
 
@@ -138,7 +138,7 @@ def specs(
     raise Exit()
 
 
-@get_typer.command(help="List capture configs.")
+@get_typer.command(help="List capture configs.", deprecated=True)
 def capture_configs() -> None:
 
     jsend_dict = safe_request(f"spectre-data/configs", "GET")
@@ -147,17 +147,40 @@ def capture_configs() -> None:
     raise Exit()
 
 
-@get_typer.command(help="Print capture config file contents.")
+@get_typer.command(help="List configs.")
+def configs() -> None:
+
+    jsend_dict = safe_request(f"spectre-data/configs", "GET")
+    endpoints = jsend_dict["data"]
+    secho_existing_resources(endpoints)
+    raise Exit()
+
+
+@get_typer.command(help="Print capture config file contents.", deprecated=True)
 def capture_config(
     tag: str = Option(None, "--tag", "-t", help="The unique identifier."),
     file_name: str = Option(None, "-f", help="The file name.", metavar="<tag>.json"),
 ) -> None:
 
-    file_name = get_capture_config_file_name(file_name, tag)
+    file_name = get_config_file_name(file_name, tag)
 
     jsend_dict = safe_request(f"spectre-data/configs/{file_name}/raw", "GET")
     capture_config = jsend_dict["data"]
     pprint_dict(capture_config)
+    raise Exit()
+
+
+@get_typer.command(help="Print config file contents.")
+def config(
+    tag: str = Option(None, "--tag", "-t", help="The unique identifier."),
+    file_name: str = Option(None, "-f", help="The file name.", metavar="<tag>.json"),
+) -> None:
+
+    file_name = get_config_file_name(file_name, tag)
+
+    jsend_dict = safe_request(f"spectre-data/configs/{file_name}/raw", "GET")
+    config = jsend_dict["data"]
+    pprint_dict(config)
     raise Exit()
 
 

--- a/cli/src/spectre_cli/commands/get.py
+++ b/cli/src/spectre_cli/commands/get.py
@@ -51,7 +51,7 @@ def log(
     raise Exit()
 
 
-@get_typer.command(help="List batch files.")
+@get_typer.command(help="List batch files.", deprecated=True)
 def batch_files(
     extensions: list[str] = Option(
         [],
@@ -74,6 +74,44 @@ def batch_files(
     day: int = Option(
         None, "--day", "-d", help="Only list batch files under this day."
     ),
+) -> None:
+    params = {
+        "extension": extensions,
+        "tag": tags,
+        "year": year,
+        "month": month,
+        "day": day,
+    }
+    jsend_dict = safe_request(
+        f"spectre-data/batches",
+        "GET",
+        params=params,
+    )
+    endpoints = jsend_dict["data"]
+
+    secho_existing_resources(endpoints)
+    raise Exit()
+
+
+@get_typer.command(help="List files.")
+def files(
+    extensions: list[str] = Option(
+        [],
+        "--extension",
+        "-e",
+        help="List all files with this file extension. If not provided, list files with any extension.",
+    ),
+    tags: list[str] = Option(
+        [],
+        "--tag",
+        "-t",
+        help="List all files with this tag. If not provided, list files with any tag.",
+    ),
+    year: int = Option(None, "--year", "-y", help="Only list files under this year."),
+    month: int = Option(
+        None, "--month", "-m", help="Only list files under this month."
+    ),
+    day: int = Option(None, "--day", "-d", help="Only list files under this day."),
 ) -> None:
     params = {
         "extension": extensions,
@@ -184,7 +222,7 @@ def config(
     raise Exit()
 
 
-@get_typer.command(help="List tags with existing batch files.")
+@get_typer.command(help="List tags with existing files.")
 def tags(
     year: int = Option(
         None,

--- a/cli/src/spectre_cli/commands/record.py
+++ b/cli/src/spectre_cli/commands/record.py
@@ -8,7 +8,7 @@ from yaspin import yaspin
 from ._utils import safe_request
 
 
-start_typer = typer.Typer(help="Start a job.")
+record_typer = typer.Typer(help="Start a job.")
 
 _DEFAULT_DURATION = 0
 _DEFAULT_MAX_RESTARTS = 5
@@ -17,8 +17,8 @@ _DEFAULT_SKIP_VALIDATION = False
 _IN_PROGRESS = "In progress... "
 
 
-@start_typer.command(help="Capture data from an SDR in real time.", deprecated=True)
-def capture(
+@record_typer.command(help="Capture data from an SDR in real time.")
+def signal(
     tag: str = typer.Option(..., "--tag", "-t", help="The capture config tag."),
     seconds: int = typer.Option(
         _DEFAULT_DURATION,
@@ -61,15 +61,14 @@ def capture(
         "validate": not skip_validation,
     }
     with yaspin(text=_IN_PROGRESS):
-        _ = safe_request("jobs/capture", "POST", json=json)
+        _ = safe_request("jobs/signal", "POST", json=json)
     raise typer.Exit()
 
 
-@start_typer.command(
-    help="Capture data from an SDR and post-process it into spectrograms in real time.",
-    deprecated=True,
+@record_typer.command(
+    help="Capture data from an SDR and post-process it into spectrograms in real time."
 )
-def session(
+def spectrograms(
     tag: str = typer.Option(..., "--tag", "-t", help="The capture config tag."),
     seconds: int = typer.Option(
         _DEFAULT_DURATION,
@@ -112,5 +111,5 @@ def session(
         "validate": not skip_validation,
     }
     with yaspin(text=_IN_PROGRESS):
-        _ = safe_request("jobs/session", "POST", json=json)
+        _ = safe_request("jobs/spectrograms", "POST", json=json)
     raise typer.Exit()

--- a/cli/src/spectre_cli/commands/record.py
+++ b/cli/src/spectre_cli/commands/record.py
@@ -8,7 +8,7 @@ from yaspin import yaspin
 from ._utils import safe_request
 
 
-record_typer = typer.Typer(help="Start a job.")
+record_typer = typer.Typer(help="Start recording data.")
 
 _DEFAULT_DURATION = 0
 _DEFAULT_MAX_RESTARTS = 5
@@ -23,32 +23,32 @@ def signal(
     seconds: int = typer.Option(
         _DEFAULT_DURATION,
         "--seconds",
-        help="The seconds component of the job duration.",
+        help="The seconds component of the duration.",
     ),
     minutes: int = typer.Option(
         _DEFAULT_DURATION,
         "--minutes",
-        help="The minutes component of the job duration.",
+        help="The minutes component of the duration.",
     ),
     hours: int = typer.Option(
         _DEFAULT_DURATION,
         "--hours",
-        help="The hours component of the job duration.",
+        help="The hours component of the duration.",
     ),
     force_restart: bool = typer.Option(
         _DEFAULT_FORCE_RESTART,
         "--force-restart",
-        help="If specified, restart all workers if one dies unexpectedly.",
+        help="If specified, restart if an error occurs at runtime.",
     ),
     max_restarts: int = typer.Option(
         _DEFAULT_MAX_RESTARTS,
         "--max-restarts",
-        help="Maximum number of times workers can be restarted before giving up and killing all workers.",
+        help="Maximum number of times to restart before giving up.",
     ),
     skip_validation: bool = typer.Option(
         _DEFAULT_SKIP_VALIDATION,
         "--skip-validation",
-        help="If specified, do not validate parameters.",
+        help="If specified, do not validate config parameters.",
     ),
 ) -> None:
     json = {
@@ -73,32 +73,32 @@ def spectrograms(
     seconds: int = typer.Option(
         _DEFAULT_DURATION,
         "--seconds",
-        help="The seconds component of the job duration.",
+        help="The seconds component of the duration.",
     ),
     minutes: int = typer.Option(
         _DEFAULT_DURATION,
         "--minutes",
-        help="The minutes component of the job duration.",
+        help="The minutes component of the duration.",
     ),
     hours: int = typer.Option(
         _DEFAULT_DURATION,
         "--hours",
-        help="The hours component of the job duration.",
+        help="The hours component of the duration.",
     ),
     force_restart: bool = typer.Option(
         _DEFAULT_FORCE_RESTART,
         "--force-restart",
-        help="If specified, restart all workers if one dies unexpectedly.",
+        help="If specified, restart if an error occurs at runtime.",
     ),
     max_restarts: int = typer.Option(
         _DEFAULT_MAX_RESTARTS,
         "--max-restarts",
-        help="Maximum number of times workers can be restarted before giving up and killing all workers.",
+        help="Maximum number of times to restart before giving up.",
     ),
     skip_validation: bool = typer.Option(
         _DEFAULT_SKIP_VALIDATION,
         "--skip-validation",
-        help="If specified, do not validate parameters.",
+        help="If specified, do not validate config parameters.",
     ),
 ) -> None:
     json = {

--- a/cli/src/spectre_cli/commands/update.py
+++ b/cli/src/spectre_cli/commands/update.py
@@ -5,7 +5,7 @@
 from typer import Typer, Option, Exit, secho
 from typing import List
 
-from ._utils import safe_request, get_capture_config_file_name
+from ._utils import safe_request, get_config_file_name
 
 
 update_typer = Typer(help="Update resources.")
@@ -15,7 +15,7 @@ def _secho_updated_resource(endpoint: str) -> None:
     secho(endpoint, fg="green")
 
 
-@update_typer.command(help="Update capture config parameters.")
+@update_typer.command(help="Update capture config parameters.", deprecated=True)
 def capture_config(
     tag: str = Option(None, "--tag", "-t", help="The unique identifier."),
     file_name: str = Option(None, "-f", help="The file name.", metavar="<tag>.json"),
@@ -38,7 +38,39 @@ def capture_config(
     ),
 ) -> None:
 
-    file_name = get_capture_config_file_name(file_name, tag)
+    file_name = get_config_file_name(file_name, tag)
+
+    json = {"params": params, "force": force, "validate": not skip_validation}
+    jsend_dict = safe_request(f"spectre-data/configs/{file_name}", "PATCH", json=json)
+    endpoint = jsend_dict["data"]
+    _secho_updated_resource(endpoint)
+    raise Exit()
+
+
+@update_typer.command(help="Update config parameters.")
+def config(
+    tag: str = Option(None, "--tag", "-t", help="The unique identifier."),
+    file_name: str = Option(None, "-f", help="The file name.", metavar="<tag>.json"),
+    params: List[str] = Option(
+        [],
+        "--param",
+        "-p",
+        help="Parameters as key-value pairs.",
+        metavar="<key>=<value>",
+    ),
+    force: bool = Option(
+        False,
+        "--force",
+        help="If specified, force the operation even if batch files exist with the same tag.",
+    ),
+    skip_validation: bool = Option(
+        False,
+        "--skip-validation",
+        help="If specified, do not validate the parameters.",
+    ),
+) -> None:
+
+    file_name = get_config_file_name(file_name, tag)
 
     json = {"params": params, "force": force, "validate": not skip_validation}
     jsend_dict = safe_request(f"spectre-data/configs/{file_name}", "PATCH", json=json)

--- a/cli/src/spectre_cli/commands/update.py
+++ b/cli/src/spectre_cli/commands/update.py
@@ -29,7 +29,7 @@ def capture_config(
     force: bool = Option(
         False,
         "--force",
-        help="If specified, force the operation even if batch files exist with the same tag.",
+        help="If specified, force the operation even if files exist with the same tag.",
     ),
     skip_validation: bool = Option(
         False,
@@ -61,7 +61,7 @@ def config(
     force: bool = Option(
         False,
         "--force",
-        help="If specified, force the operation even if batch files exist with the same tag.",
+        help="If specified, force the operation even if files exist with the same tag.",
     ),
     skip_validation: bool = Option(
         False,


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Renamed several CLI commands to improve user experience by making them more intuitive and reducing how much users have to type. All original commands remain functional but are now deprecated, to be phased out at the next major release. In particular: 

- `capture-config` → `config` (shortened)
- `batch-files` → `files` (shortened) 
- `start capture` → `record signal` (more intuitive)
- `start session` → `record spectrograms` (more intuitive)

The renamed commands have identical functionality to their original counterparts.

## Issue
<!-- Add the link to the related issue(s) -->
>n/a

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [ ] My changes are covered by unit tests
- [ ] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
> n/a
