### PR TITLE
Remove unsupported CLI command 'get specs'

### DIFF
--- a/cli/src/spectre_cli/commands/get.py
+++ b/cli/src/spectre_cli/commands/get.py
@@ -197,15 +197,13 @@ def model(
     ),
     receiver_mode: str = typer.Option(
         ..., "--mode", "-m", help="The operating mode of the receiver."
-    )
+    ),
 ) -> None:
 
     params = {
         "receiver_mode": receiver_mode,
     }
-    jsend_dict = safe_request(
-        f"receivers/{receiver_name}/model", "GET", params=params
-    )
+    jsend_dict = safe_request(f"receivers/{receiver_name}/model", "GET", params=params)
     model = jsend_dict["data"]
     pprint_dict(model)
     typer.Exit()

--- a/cli/src/spectre_cli/commands/record.py
+++ b/cli/src/spectre_cli/commands/record.py
@@ -19,7 +19,8 @@ def signal(
     tags: list[str] = typer.Option(..., "--tag", "-t", help="The config tag."),
     duration: float = typer.Option(
         ...,
-        "--duration", "-d",
+        "--duration",
+        "-d",
         help="How long to record the signal for, in seconds.",
     ),
     force_restart: bool = typer.Option(
@@ -57,7 +58,8 @@ def spectrograms(
     tags: list[str] = typer.Option(..., "--tag", "-t", help="The config tag."),
     duration: float = typer.Option(
         ...,
-        "--duration", "-d",
+        "--duration",
+        "-d",
         help="How long to record the signal for, in seconds.",
     ),
     force_restart: bool = typer.Option(


### PR DESCRIPTION
This pull request removes the `specs` command from the `get.py` CLI commands. This command was previously used to print receiver hardware specifications.

Command removal:

* Removed the `specs` command from `cli/src/spectre_cli/commands/get.py`, which previously allowed users to print hardware specifications for a specified receiver.