### PR TITLE
fix: issue-220 Simplify how spectrograms are averaged

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -422,7 +422,7 @@ COPY gunicorn.conf.py /opt/spectre_server/
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.3.2-alpha" \
+      version="3.3.3-alpha" \
       description="Docker image for running the `spectre-server`." \
       license="GPL-3.0-or-later"
 
@@ -504,7 +504,7 @@ CMD ["/app/cmd.sh"]
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.3.2-alpha" \
+      version="3.3.3-alpha" \
       description="Docker image for  developing the `spectre-server`." \
       license="GPL-3.0-or-later"
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-server"
-version = "3.3.2-alpha"
+version = "3.3.3-alpha"
 authors = [
   { name = "Jimmy Fitzpatrick", email = "jimmy@spectregrams.org" }
 ]

--- a/backend/src/spectre_server/__init__.py
+++ b/backend/src/spectre_server/__init__.py
@@ -2,6 +2,6 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "3.3.2-alpha"
+__version__ = "3.3.3-alpha"
 
 __all__ = ["core", "routes", "services"]

--- a/backend/src/spectre_server/core/events/_fixed_center_frequency.py
+++ b/backend/src/spectre_server/core/events/_fixed_center_frequency.py
@@ -121,10 +121,11 @@ class FixedCenterFrequency(
         )
 
         spectrogram = spectre_server.core.spectrograms.time_average(
-            spectrogram, resolution=self.__model.time_resolution
+            spectrogram, max(self.__model.time_resolution, spectrogram.time_resolution)
         )
         spectrogram = spectre_server.core.spectrograms.frequency_average(
-            spectrogram, resolution=self.__model.frequency_resolution
+            spectrogram,
+            max(self.__model.frequency_resolution, spectrogram.frequency_resolution),
         )
 
         _LOGGER.info("Spectrogram created successfully")

--- a/backend/src/spectre_server/core/events/_swept_center_frequency.py
+++ b/backend/src/spectre_server/core/events/_swept_center_frequency.py
@@ -479,10 +479,11 @@ class SweptCenterFrequency(
         )
 
         spectrogram = spectre_server.core.spectrograms.time_average(
-            spectrogram, resolution=self.__model.time_resolution
+            spectrogram, max(self.__model.time_resolution, spectrogram.time_resolution)
         )
         spectrogram = spectre_server.core.spectrograms.frequency_average(
-            spectrogram, resolution=self.__model.frequency_resolution
+            spectrogram,
+            max(self.__model.frequency_resolution, spectrogram.frequency_resolution),
         )
 
         # If the previous batch exists, then by this point it has already been processed.

--- a/backend/src/spectre_server/core/spectrograms/_array_operations.py
+++ b/backend/src/spectre_server/core/spectrograms/_array_operations.py
@@ -8,65 +8,54 @@ import numpy as np
 import numpy.typing as npt
 
 
-def average_array(
-    array: npt.NDArray[np.float32], average_over: int, axis: int = 0
+def moving_average(
+    array: npt.NDArray[np.float32], window_size: int, axis: int = 0
 ) -> npt.NDArray[np.float32]:
-    """
-    Averages elements of an array in blocks along a specified axis.
+    """Applies a moving average along a specified axis by computing the arithmetic mean
+    over non-overlapping but exactly adjacent windows.
 
     :param array: Input array to be averaged.
-    :param average_over: Number of elements in each averaging block.
+    :param window_size: Number of items in the window.
     :param axis: Axis along which to perform the averaging, defaults to 0.
-    :raises TypeError: If `average_over` is not an integer.
-    :raises ValueError: If `average_over` is not in the range [1, size of the axis].
-    :raises ValueError: If `axis` is out of bounds for the array.
-    :return: Array of averaged values along the specified axis.
+    :return: A new array, averaged along the specified axis.
     """
-
-    # Get the size of the specified axis which we will average over
-    axis_size = array.shape[axis]
-    # Check if average_over is within the valid range
-    if not 1 <= average_over <= axis_size:
+    if window_size < 1:
         raise ValueError(
-            f"average_over must be between 1 and the length of the axis ({axis_size})"
+            f"Cannot average over windows of size {window_size}, must be more than one"
         )
 
-    max_axis_index = len(np.shape(array)) - 1
-    if axis > max_axis_index:  # zero indexing on specifying axis, so minus one
+    axis_length = array.shape[axis]
+    if window_size > axis_length:
         raise ValueError(
-            f"Requested axis is out of range of array dimensions. Axis: {axis}, max axis index: {max_axis_index}"
+            f"The window size ({window_size}) cannot be greater than the length of the axis ({axis})"
+            f"Got axis length {axis_length}"
         )
 
-    # find the number of elements in the requested axis
-    num_elements = array.shape[axis]
+    if window_size == 1:
+        # Nothing to do - arithmetic mean of one sample is itself.
+        return array
 
-    # find the number of "full blocks" to average over
-    num_full_blocks = num_elements // average_over
-    # if num_elements is not exactly divisible by average_over, we will have some elements left over
-    # these remaining elements will be padded with nans to become another full block
-    remainder = num_elements % average_over
+    num_windows: float = axis_length / window_size
 
-    # if there exists a remainder, pad the last block
-    if remainder != 0:
-        # initialise an array to hold the padding shape
-        padding_shape = [(0, 0)] * array.ndim
-        # pad after the last column in the requested axis
-        padding_shape[axis] = (0, average_over - remainder)
-        # pad with nan values (so to not contribute towards the mean computation)
-        array = np.pad(array, padding_shape, mode="constant", constant_values=np.nan)
+    # Force the axis length to be a multiple of the window size, so if the last window is partial,
+    # we just average over remaining elements.
+    if not num_windows.is_integer():
 
-    # initalise a list to hold the new shape
+        # We only need to pad the end of the axis we're averaging over.
+        width = window_size - axis_length % window_size
+        pad_widths = [(0, 0) for _ in range(array.ndim)]
+        pad_widths[axis] = (0, width)
+
+        # Turn the partial window at the end into a full window.
+        array = np.pad(
+            array, pad_width=pad_widths, mode="constant", constant_values=(np.nan,)
+        )
+        num_windows += 1
+
     new_shape = list(array.shape)
-    # update the shape on the requested access (to the number of blocks we will average over)
-    new_shape[axis] = num_full_blocks + (1 if remainder else 0)
-    # insert a new dimension, with the size of each block
-    new_shape.insert(axis + 1, average_over)
-    # and reshape the array to sort the array into the relevant blocks.
-    reshaped_array = array.reshape(new_shape)
-    # average over the newly created axis, essentially averaging over the blocks.
-    averaged_array = np.nanmean(reshaped_array, axis=axis + 1)
-    # return the averaged array
-    return averaged_array
+    new_shape[axis] = int(num_windows)
+    new_shape.insert(axis + 1, window_size)
+    return np.nanmean(array.reshape(new_shape), axis=axis + 1)
 
 
 T = typing.TypeVar("T", np.float32, np.datetime64)

--- a/backend/src/spectre_server/core/spectrograms/_array_operations.py
+++ b/backend/src/spectre_server/core/spectrograms/_array_operations.py
@@ -54,7 +54,7 @@ def moving_average(
         num_windows += 1
 
     new_shape = list(array.shape)
-    new_shape[axis] = int(num_windows)
+    new_shape[axis] = num_windows
     new_shape.insert(axis + 1, window_size)
     return np.nanmean(array.reshape(new_shape), axis=axis + 1)
 

--- a/backend/src/spectre_server/core/spectrograms/_array_operations.py
+++ b/backend/src/spectre_server/core/spectrograms/_array_operations.py
@@ -35,14 +35,15 @@ def moving_average(
         # Nothing to do - arithmetic mean of one sample is itself.
         return array
 
-    num_windows: float = axis_length / window_size
+    num_windows = axis_length // window_size
+    remainder = axis_length % window_size
 
     # Force the axis length to be a multiple of the window size, so if the last window is partial,
     # we just average over remaining elements.
-    if not num_windows.is_integer():
+    if remainder:
 
         # We only need to pad the end of the axis we're averaging over.
-        width = window_size - axis_length % window_size
+        width = window_size - remainder
         pad_widths = [(0, 0) for _ in range(array.ndim)]
         pad_widths[axis] = (0, width)
 

--- a/backend/src/spectre_server/core/spectrograms/_transform.py
+++ b/backend/src/spectre_server/core/spectrograms/_transform.py
@@ -2,12 +2,12 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import numpy as np
 import datetime
-import typing
 import math
 
-from ._array_operations import find_closest_index, average_array, time_elapsed
+import numpy as np
+
+from ._array_operations import find_closest_index, moving_average, time_elapsed
 from ._spectrogram import Spectrogram
 
 
@@ -132,103 +132,76 @@ def time_chop(
     )
 
 
-def _validate_and_compute_average_over(
-    original_resolution: float, resolution: typing.Optional[float], average_over: int
-) -> int:
-    """
-    Validates the input parameters and computes `average_over` if `resolution` is specified.
-
-    :param resolution: The desired resolution for averaging. Mutually exclusive with `average_over`.
-    :param average_over: The number of consecutive spectrums to average over. Mutually exclusive with `resolution`.
-    :param original_resolution: The original resolution (e.g., time or frequency).
-    :raises ValueError: If neither or both `resolution` and `average_over` are specified.
-    :return: The computed or validated `average_over` value.
-    """
-    if (resolution is None) and (average_over == 1):
-        return average_over
-
-    if not (resolution is not None) ^ (average_over != 1):
-        raise ValueError(
-            "Exactly one of 'resolution' or 'average_over' must be specified."
-        )
-
-    if resolution is not None:
-        return max(1, math.floor(resolution / original_resolution))
-
-    else:
-        return average_over
-
-
-def time_average(
-    spectrogram: Spectrogram,
-    resolution: typing.Optional[float] = None,
-    average_over: int = 1,
-) -> Spectrogram:
-    """
-    Performs time averaging on the spectrogram data.
+def time_average(spectrogram: Spectrogram, resolution: float) -> Spectrogram:
+    """Average a spectrogram in time to a desired resolution by applying a moving average.
 
     :param spectrogram: The input spectrogram to process.
-    :param resolution: The desired time resolution for averaging (seconds). Mutually exclusive with `average_over`.
-    :param average_over: The number of consecutive time points to average. Mutually exclusive with `resolution`.
-    :raises NotImplementedError: If the spectrogram lacks a defined start datetime.
-    :raises ValueError: If neither or both `resolution` and `average_over` are specified.
-    :return: A new spectrogram with time-averaged data.
+    :param resolution: The desired time resolution.
     """
-    if not spectrogram.start_datetime_is_set:
-        raise NotImplementedError(
-            "Time averaging is not supported for spectrograms without an assigned start datetime."
+
+    if resolution < spectrogram.time_resolution:
+        raise ValueError(
+            f"Desired time resolution {resolution} is less than the current {spectrogram.time_resolution}"
         )
 
-    average_over = _validate_and_compute_average_over(
-        spectrogram.time_resolution, resolution, average_over
+    if resolution >= spectrogram.time_range:
+        raise ValueError(
+            f"Desired time resolution {resolution} must be less than the time range {spectrogram.time_range}"
+        )
+
+    window_size = math.floor(resolution / spectrogram.time_resolution)
+    transformed_dynamic_spectra = moving_average(
+        spectrogram.dynamic_spectra, window_size, axis=1
     )
 
-    transformed_dynamic_spectra = average_array(
-        spectrogram.dynamic_spectra, average_over, axis=1
-    )
-
-    # Take the start time of each block (this preserves the original start time.)
-    transformed_times = spectrogram.times[0::average_over]
+    # Assign the start time of each window to as the time of each spectrum in the new spectrogram.
+    # This preserves the time of the first spectrum before and after the transformation.
+    transformed_times = spectrogram.times[0::window_size]
 
     return Spectrogram(
         transformed_dynamic_spectra,
         transformed_times,
         spectrogram.frequencies,
         spectrogram.spectrum_unit,
-        spectrogram.start_datetime,
+        start_datetime=(
+            spectrogram.start_datetime if spectrogram.start_datetime_is_set else None
+        ),
     )
 
 
-def frequency_average(
-    spectrogram: Spectrogram,
-    resolution: typing.Optional[float] = None,
-    average_over: int = 1,
-) -> Spectrogram:
-    """
-    Performs frequency averaging on the spectrogram data.
+def frequency_average(spectrogram: Spectrogram, resolution: float) -> Spectrogram:
+    """Average a spectrogram in frequency to a desired resolution by applying a moving average.
 
     :param spectrogram: The input spectrogram to process.
-    :param resolution: The desired frequency resolution for averaging (Hz). Mutually exclusive with `average_over`.
-    :param average_over: The number of consecutive frequency bins to average. Mutually exclusive with `resolution`.
-    :raises ValueError: If neither or both `resolution` and `average_over` are specified.
-    :return: A new spectrogram with frequency-averaged data.
+    :param resolution: The desired frequency resolution.
     """
-    average_over = _validate_and_compute_average_over(
-        spectrogram.frequency_resolution, resolution, average_over
+
+    if resolution < spectrogram.frequency_resolution:
+        raise ValueError(
+            f"Desired frequency resolution {resolution} is less than the current {spectrogram.frequency_resolution}"
+        )
+
+    if resolution >= spectrogram.frequency_range:
+        raise ValueError(
+            f"Desired frequency resolution {resolution} must be less than the frequency range {spectrogram.time_range}"
+        )
+
+    window_size = math.floor(resolution / spectrogram.frequency_resolution)
+    transformed_dynamic_spectra = moving_average(
+        spectrogram.dynamic_spectra, window_size, axis=0
     )
 
-    # Perform averaging
-    transformed_dynamic_spectra = average_array(
-        spectrogram.dynamic_spectra, average_over, axis=0
-    )
-    transformed_frequencies = average_array(spectrogram.frequencies, average_over)
+    # Contrary to the time average, average over the frequencies corresponding to each spectral component per window.
+    transformed_frequencies = moving_average(spectrogram.frequencies, window_size)
 
     return Spectrogram(
         transformed_dynamic_spectra,
         spectrogram.times,
         transformed_frequencies,
         spectrogram.spectrum_unit,
-        spectrogram.start_datetime,
+        start_datetime=(
+            spectrogram.start_datetime if spectrogram.start_datetime_is_set else None
+        ),
     )
 
 

--- a/backend/tests/unit/core/test_spectrograms.py
+++ b/backend/tests/unit/core/test_spectrograms.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: © 2024-2026 Jimmy Fitzpatrick <jimmy@spectregrams.org>
+# This file is part of SPECTRE
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pytest
+import numpy as np
+
+import spectre_server.core.spectrograms
+
+
+@pytest.fixture
+def spectrogram() -> spectre_server.core.spectrograms.Spectrogram:
+    """Create the following spectrogram:
+
+    1MHz  | 0    1    2    3   4   5   |
+    2MHz  | 6    7    8    9   10  11  |
+    3MHz  | 12   13   14   15  16  17  |
+    4MHz  | 18   19   20   21  22  23  |
+            0.0  0.2  0.4  0.6 0.8 1.0 [s]
+    """
+    dynamic_spectra = np.array(
+        [
+            [0, 1, 2, 3, 4, 5],
+            [6, 7, 8, 9, 10, 11],
+            [12, 13, 14, 15, 16, 17],
+            [18, 19, 20, 21, 22, 23],
+        ],
+        dtype=np.float32,
+    )
+    times = np.array([0.00, 0.20, 0.40, 0.60, 0.80, 1.0])
+    frequencies = np.array([1e6, 2e6, 3e6, 4e6])
+    return spectre_server.core.spectrograms.Spectrogram(
+        dynamic_spectra,
+        times,
+        frequencies,
+        spectre_server.core.spectrograms.SpectrumUnit.AMPLITUDE,
+    )
+
+
+class TestTimeAverage:
+    def test_resolution_too_small(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+    ) -> None:
+        """Check an error is raised when the desired time resolution is less than the current."""
+        with pytest.raises(ValueError):
+            spectre_server.core.spectrograms.time_average(spectrogram, 0.1)
+
+    def test_resolution_too_big(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+    ) -> None:
+        """Check an error is raised when the desired time resolution is more than the time spanned by the spectrogram."""
+        with pytest.raises(ValueError):
+            spectre_server.core.spectrograms.time_average(spectrogram, 1.0)
+
+    def test_no_change_at_current_resolution(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+    ) -> None:
+        """Check that we get back the spectrogram unchanged when the time resolution is equal to the current."""
+        averaged_s = spectre_server.core.spectrograms.time_average(spectrogram, 0.2)
+        assert spectrogram.time_resolution == averaged_s.time_resolution
+        assert np.array_equal(averaged_s.times, spectrogram.times)
+        assert np.array_equal(averaged_s.frequencies, spectrogram.frequencies)
+        assert np.array_equal(averaged_s.dynamic_spectra, spectrogram.dynamic_spectra)
+
+    @pytest.mark.parametrize(
+        "resolution, expected_resolution, expected_dynamic_spectra, expected_times",
+        [
+            # Impossible resolution, moving average divides 6 spectra into 3 full windows.
+            pytest.param(
+                0.45,
+                0.4,
+                [
+                    [0.5, 2.5, 4.5],
+                    [6.5, 8.5, 10.5],
+                    [12.5, 14.5, 16.5],
+                    [18.5, 20.5, 22.5],
+                ],
+                [0, 0.4, 0.8],
+            ),
+            # Impossible resolution, moving average divides 6 spectra into 1 full window, 1 partial.
+            pytest.param(
+                0.85,
+                0.8,
+                [[1.5, 4.5], [7.5, 10.5], [13.5, 16.5], [19.5, 22.5]],
+                [0, 0.8],
+            ),
+            # Exact resolution, moving average divides 6 spectra into 1 full window, 1 partial.
+            pytest.param(
+                0.8,
+                0.8,
+                [[1.5, 4.5], [7.5, 10.5], [13.5, 16.5], [19.5, 22.5]],
+                [0, 0.8],
+            ),
+        ],
+    )
+    def test_averaging(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+        resolution: float,
+        expected_resolution: float,
+        expected_dynamic_spectra: list[list[float]],
+        expected_times: list[float],
+    ) -> None:
+        """Check that time averaging yields the correct resolution, dynamic spectra, times, and frequencies."""
+        averaged_s = spectre_server.core.spectrograms.time_average(
+            spectrogram, resolution
+        )
+        assert averaged_s.time_resolution == expected_resolution
+        assert np.allclose(
+            averaged_s.dynamic_spectra,
+            np.array(expected_dynamic_spectra, dtype=np.float32),
+        )
+        assert np.allclose(averaged_s.times, np.array(expected_times, dtype=np.float32))
+        assert np.allclose(averaged_s.frequencies, spectrogram.frequencies)
+
+
+class TestFrequencyAverage:
+    def test_resolution_too_small(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+    ) -> None:
+        """Check an error is raised when the desired frequency resolution is less than the current."""
+        with pytest.raises(ValueError):
+            spectre_server.core.spectrograms.frequency_average(spectrogram, 0.5e6)
+
+    def test_resolution_too_big(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+    ) -> None:
+        """Check an error is raised when the desired frequency resolution is more than the frequency spanned by the spectrogram."""
+        with pytest.raises(ValueError):
+            spectre_server.core.spectrograms.frequency_average(spectrogram, 3e6)
+
+    def test_no_change_at_current_resolution(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+    ) -> None:
+        """Check that we get back the spectrogram unchanged when the frequency resolution is equal to the current."""
+        averaged_s = spectre_server.core.spectrograms.frequency_average(
+            spectrogram, 1e6
+        )
+        assert spectrogram.frequency_resolution == averaged_s.frequency_resolution
+        assert np.array_equal(averaged_s.frequencies, spectrogram.frequencies)
+        assert np.array_equal(averaged_s.times, spectrogram.times)
+        assert np.array_equal(averaged_s.dynamic_spectra, spectrogram.dynamic_spectra)
+
+    @pytest.mark.parametrize(
+        "resolution, expected_resolution, expected_dynamic_spectra, expected_frequencies",
+        [
+            # Impossible resolution, moving average divides 4 frequency bins into 2 full windows.
+            pytest.param(
+                2.5e6,
+                2e6,
+                [
+                    [3, 4, 5, 6, 7, 8],
+                    [15, 16, 17, 18, 19, 20],
+                ],
+                [1.5e6, 3.5e6],
+            ),
+            # Exact resolution, moving average divides 4 frequency bins into 2 full windows.
+            pytest.param(
+                2e6,
+                2e6,
+                [
+                    [3, 4, 5, 6, 7, 8],
+                    [15, 16, 17, 18, 19, 20],
+                ],
+                [1.5e6, 3.5e6],
+            ),
+        ],
+    )
+    def test_averaging(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+        resolution: float,
+        expected_resolution: float,
+        expected_dynamic_spectra: list[list[float]],
+        expected_frequencies: list[float],
+    ) -> None:
+        """Check that frequency averaging yields the correct resolution, dynamic spectra, frequencies, and times."""
+        averaged_s = spectre_server.core.spectrograms.frequency_average(
+            spectrogram, resolution
+        )
+        assert averaged_s.frequency_resolution == expected_resolution
+        assert np.allclose(
+            averaged_s.dynamic_spectra,
+            np.array(expected_dynamic_spectra, dtype=np.float32),
+        )
+        assert np.allclose(
+            averaged_s.frequencies,
+            np.array(expected_frequencies, dtype=np.float32),
+        )
+        assert np.allclose(averaged_s.times, spectrogram.times)

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install .
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.3.2-alpha" \
+      version="3.3.3-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 
@@ -57,7 +57,7 @@ USER appuser
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.3.2-alpha" \
+      version="3.3.3-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-cli"
-version = "3.3.2-alpha"
+version = "3.3.3-alpha"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jimmy@spectregrams.org" },
 ]

--- a/cli/src/spectre_cli/__init__.py
+++ b/cli/src/spectre_cli/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "3.3.2-alpha"
+__version__ = "3.3.3-alpha"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   spectre-server:
     container_name: spectre-server
-    image: spectregrams/spectre-server:3.3.2-alpha
+    image: spectregrams/spectre-server:3.3.3-alpha
     environment:
       - SPECTRE_GID=${SPECTRE_GID}
       - SPECTRE_BIND_HOST=${SPECTRE_BIND_HOST}
@@ -20,7 +20,7 @@ services:
 
   spectre-cli:
     container_name: spectre-cli
-    image: spectregrams/spectre-cli:3.3.2-alpha
+    image: spectregrams/spectre-cli:3.3.3-alpha
     environment:
       - SPECTRE_SERVER_HOST=${SPECTRE_SERVER_HOST}
       - SPECTRE_SERVER_PORT=${SPECTRE_SERVER_PORT}


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Refactor and simplify the functions which average the spectrograms and provide test coverage where none existed before.

## Issue link
<!-- Add the link to the related issue(s) -->
[issue-220](https://github.com/spectregrams/spectre/issues/220)

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [X] My changes are covered by unit tests
- [X] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
> n/a
