### PR TITLE
feat: issue-219 Support for the RX-888 MK II

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -443,7 +443,7 @@ COPY gunicorn.conf.py /opt/spectre_server/
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.3.3-alpha" \
+      version="3.4.0-alpha" \
       description="Docker image for running the `spectre-server`." \
       license="GPL-3.0-or-later"
 
@@ -528,7 +528,7 @@ CMD ["/app/cmd.sh"]
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.3.3-alpha" \
+      version="3.4.0-alpha" \
       description="Docker image for  developing the `spectre-server`." \
       license="GPL-3.0-or-later"
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -343,6 +343,27 @@ RUN git clone --depth 1 -b soapy-rtl-sdr-0.3.3 https://github.com/pothosware/Soa
     rm -rf /tmp/*
 
 # --------------------------------------------- #
+# Install the Soapy SDDC plugin.
+# --------------------------------------------- #
+FROM build AS soapy_sddc
+
+WORKDIR /tmp
+
+# TODO: At the time of writing, there's nothing to pin since the [latest tag](https://github.com/ik1xpv/ExtIO_sddc/releases/tag/v1.2.0) 
+# does not provide the Soapy plugin. A stable fork is used instead, for consistent builds. Revisit this when we can pin the version from the 
+# official repository.
+RUN git clone --depth 1 https://github.com/spectregrams/ExtIO_sddc && \
+    cd ExtIO_sddc && \
+    mkdir build && \
+    cd build && \
+    cmake -Wno-dev \
+          -DCMAKE_INSTALL_PREFIX=/opt/soapy_sddc \
+          .. && \
+    make -j"$(nproc)" && \
+    make install && \
+    rm -rf /tmp/*
+
+# --------------------------------------------- #
 # Shared build dependencies for OOT modules.
 # --------------------------------------------- #
 FROM build AS oot_module
@@ -446,6 +467,9 @@ COPY --from=soapy_hackrf /opt/soapy_hackrf/lib /usr/local/lib
 COPY --from=rtlsdr /opt/rtlsdr/bin /usr/bin
 COPY --from=rtlsdr /opt/rtlsdr/lib /usr/lib
 COPY --from=soapy_rtlsdr /opt/soapy_rtlsdr/lib /usr/local/lib
+
+# Copy in the sddc runtime dependencies.
+COPY --from=soapy_sddc /opt/soapy_sddc/lib /usr/local/lib
 
 # Copy in the UHD runtime dependencies.
 COPY --from=uhd /opt/uhd/lib /usr/lib

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-server"
-version = "3.3.3-alpha"
+version = "3.4.0-alpha"
 authors = [
   { name = "Jimmy Fitzpatrick", email = "jimmy@spectregrams.org" }
 ]

--- a/backend/src/spectre_server/__init__.py
+++ b/backend/src/spectre_server/__init__.py
@@ -2,6 +2,6 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "3.3.3-alpha"
+__version__ = "3.4.0-alpha"
 
 __all__ = ["core", "routes", "services"]

--- a/backend/src/spectre_server/core/flowgraphs/__init__.py
+++ b/backend/src/spectre_server/core/flowgraphs/__init__.py
@@ -41,6 +41,11 @@ from ._usrp import (
 )
 from ._hackrf import HackRFFixedCenterFrequency, HackRFFixedCenterFrequencyModel
 from ._rtlsdr import RTLSDRFixedCenterFrequency, RTLSDRFixedCenterFrequencyModel
+from ._rx888mk2 import (
+    RX888MK2FixedCenterFrequency,
+    RX888MK2FixedCenterFrequencyModel,
+    RX888MK2Port,
+)
 
 __all__ = [
     "Base",
@@ -73,4 +78,7 @@ __all__ = [
     "HackRFFixedCenterFrequencyModel",
     "RTLSDRFixedCenterFrequency",
     "RTLSDRFixedCenterFrequencyModel",
+    "RX888MK2FixedCenterFrequency",
+    "RX888MK2FixedCenterFrequencyModel",
+    "RX888MK2Port",
 ]

--- a/backend/src/spectre_server/core/flowgraphs/_rx888mk2.py
+++ b/backend/src/spectre_server/core/flowgraphs/_rx888mk2.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2024-2026 Jimmy Fitzpatrick <jimmy@spectregrams.org>
+# This file is part of SPECTRE
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import dataclasses
+
+from gnuradio import spectre
+from gnuradio import soapy
+
+import spectre_server.core.fields
+
+from ._base import Base, BaseModel
+from ._constants import FlowgraphConstant
+
+
+@dataclasses.dataclass(frozen=True)
+class RX888MK2Port:
+    """Specifies one of the antenna ports on the RX-888 MK II."""
+
+    HF = "HF"
+    VHF = "VHF"
+
+
+class RX888MK2FixedCenterFrequencyModel(BaseModel):
+    sample_rate: spectre_server.core.fields.Field.sample_rate = 8e6
+    center_frequency: spectre_server.core.fields.Field.center_frequency = 32e6
+    antenna_port: spectre_server.core.fields.Field.antenna_port = RX888MK2Port.HF
+    if_gain: spectre_server.core.fields.Field.if_gain = -24.583
+    rf_gain: spectre_server.core.fields.Field.rf_gain = -31.5
+    batch_size: spectre_server.core.fields.Field.batch_size = 3
+    output_type: spectre_server.core.fields.Field.output_type = (
+        spectre_server.core.fields.OutputType.FC32
+    )
+
+
+class RX888MK2FixedCenterFrequency(Base[RX888MK2FixedCenterFrequencyModel]):
+    def configure(self, tag: str, model: RX888MK2FixedCenterFrequencyModel) -> None:
+        device = "driver=SDDC"
+        type = model.output_type
+        nchan = 1
+        dev_args = ""
+        stream_args = ""
+        tune_args = [""]
+        settings = [""]
+        self.soapy_rx888mk2_source = soapy.source(
+            device, type, nchan, dev_args, stream_args, tune_args, settings
+        )
+        self.soapy_rx888mk2_source.set_sample_rate(0, model.sample_rate)
+        self.soapy_rx888mk2_source.set_frequency(0, model.center_frequency)
+        self.soapy_rx888mk2_source.set_antenna(0, model.antenna_port)
+        self.soapy_rx888mk2_source.set_gain(0, "RF", model.rf_gain)
+        self.soapy_rx888mk2_source.set_gain(0, "IF", model.if_gain)
+
+        self.spectre_batched_file_sink = spectre.batched_file_sink(
+            self._batches_dir_path,
+            tag,
+            model.output_type,
+            model.batch_size,
+            model.sample_rate,
+            FlowgraphConstant.GROUP_BY_DATE,
+        )
+        self.connect(
+            (self.soapy_rx888mk2_source, 0), (self.spectre_batched_file_sink, 0)
+        )

--- a/backend/src/spectre_server/core/models/__init__.py
+++ b/backend/src/spectre_server/core/models/__init__.py
@@ -18,6 +18,7 @@ from ._b200mini import B200miniFixedCenterFrequency, B200miniSweptCenterFrequenc
 from ._hackrf import HackRFFixedCenterFrequency
 from ._hackrfone import HackRFOneFixedCenterFrequency
 from ._rtlsdr import RTLSDRFixedCenterFrequency
+from ._rx888mk2 import RX888MK2FixedCenterFrequency
 
 __all__ = [
     "SignalGeneratorCosineWaveModel",
@@ -36,4 +37,5 @@ __all__ = [
     "HackRFFixedCenterFrequency",
     "HackRFOneFixedCenterFrequency",
     "RTLSDRFixedCenterFrequency",
+    "RX888MK2FixedCenterFrequency",
 ]

--- a/backend/src/spectre_server/core/models/_rx888mk2.py
+++ b/backend/src/spectre_server/core/models/_rx888mk2.py
@@ -22,6 +22,7 @@ RF_GAIN_LOWER_BOUND = -31.5
 RF_GAIN_UPPER_BOUND = 0
 IF_GAIN_LOWER_BOUND = -24.583
 IF_GAIN_UPPER_BOUND = 33.1409
+EXPECTED_OUTPUT_TYPES: list[str] = ["fc32"]
 
 
 class RX888MK2FixedCenterFrequency(
@@ -59,4 +60,5 @@ class RX888MK2FixedCenterFrequency(
             name="if_gain",
         )
         validate_one_of(self.sample_rate, HF_ALLOWED_SAMPLE_RATES, "sample_rate")
+        validate_one_of(self.output_type, EXPECTED_OUTPUT_TYPES, "output_type")
         return self

--- a/backend/src/spectre_server/core/models/_rx888mk2.py
+++ b/backend/src/spectre_server/core/models/_rx888mk2.py
@@ -10,8 +10,18 @@ import spectre_server.core.flowgraphs
 from ._validators import (
     skip_validator,
     validate_window_size,
+    validate_in_range,
+    validate_one_of,
 )
 from ._soapy_validators import validate_output_type
+
+HF_FREQ_LOWER_BOUND = 10e3
+HF_FREQ_UPPER_BOUND = 64e6
+HF_ALLOWED_SAMPLE_RATES = [2e6, 4e6, 8e6, 16e6, 32e6, 64e6]
+RF_GAIN_LOWER_BOUND = -31.5
+RF_GAIN_UPPER_BOUND = 0
+IF_GAIN_LOWER_BOUND = -24.583
+IF_GAIN_UPPER_BOUND = 33.1409
 
 
 class RX888MK2FixedCenterFrequency(
@@ -24,4 +34,29 @@ class RX888MK2FixedCenterFrequency(
             return self
         validate_window_size(self.window_size)
         validate_output_type(self.output_type)
+
+        if not self.antenna_port == spectre_server.core.flowgraphs.RX888MK2Port.HF:
+            raise ValueError(
+                f"Only the HF port is currently supported. Got {self.antenna_port}"
+            )
+
+        validate_in_range(
+            self.center_frequency,
+            lower_bound=HF_FREQ_LOWER_BOUND,
+            upper_bound=HF_FREQ_UPPER_BOUND,
+            name="center_frequency",
+        )
+        validate_in_range(
+            self.rf_gain,
+            lower_bound=RF_GAIN_LOWER_BOUND,
+            upper_bound=RF_GAIN_UPPER_BOUND,
+            name="rf_gain",
+        )
+        validate_in_range(
+            self.if_gain,
+            lower_bound=IF_GAIN_LOWER_BOUND,
+            upper_bound=IF_GAIN_UPPER_BOUND,
+            name="if_gain",
+        )
+        validate_one_of(self.sample_rate, HF_ALLOWED_SAMPLE_RATES, "sample_rate")
         return self

--- a/backend/src/spectre_server/core/models/_rx888mk2.py
+++ b/backend/src/spectre_server/core/models/_rx888mk2.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: © 2024-2026 Jimmy Fitzpatrick <jimmy@spectregrams.org>
+# This file is part of SPECTRE
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pydantic
+
+import spectre_server.core.events
+import spectre_server.core.flowgraphs
+
+from ._validators import (
+    skip_validator,
+    validate_window_size,
+)
+from ._soapy_validators import validate_output_type
+
+
+class RX888MK2FixedCenterFrequency(
+    spectre_server.core.flowgraphs.RX888MK2FixedCenterFrequencyModel,
+    spectre_server.core.events.FixedCenterFrequencyModel,
+):
+    @pydantic.model_validator(mode="after")
+    def validator(self, info: pydantic.ValidationInfo):
+        if skip_validator(info):
+            return self
+        validate_window_size(self.window_size)
+        validate_output_type(self.output_type)
+        return self

--- a/backend/src/spectre_server/core/receivers/__init__.py
+++ b/backend/src/spectre_server/core/receivers/__init__.py
@@ -26,6 +26,7 @@ from ._b200mini import B200mini
 from ._hackrf import HackRF
 from ._hackrfone import HackRFOne
 from ._rtlsdr import RTLSDR
+from ._rx888mk2 import RX888MK2
 from ._record import record_signal, record_spectrograms
 
 __all__ = [

--- a/backend/src/spectre_server/core/receivers/_names.py
+++ b/backend/src/spectre_server/core/receivers/_names.py
@@ -20,6 +20,7 @@ class ReceiverName:
     :ivar HACKRF: Any general HackRF receiver.
     :ivar HACKRFONE: Hack RF One.
     :ivar RTLSDR: RTL-SDR.
+    :ivar RX888MK2: RX-888 MK II.
     """
 
     CUSTOM = "custom"
@@ -33,3 +34,4 @@ class ReceiverName:
     HACKRF = "hackrf"
     HACKRFONE = "hackrfone"
     RTLSDR = "rtlsdr"
+    RX888MK2 = "rx888mk2"

--- a/backend/src/spectre_server/core/receivers/_rx888mk2.py
+++ b/backend/src/spectre_server/core/receivers/_rx888mk2.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: © 2024-2026 Jimmy Fitzpatrick <jimmy@spectregrams.org>
+# This file is part of SPECTRE
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import dataclasses
+
+import spectre_server.core.events
+import spectre_server.core.flowgraphs
+import spectre_server.core.models
+import spectre_server.core.batches
+
+from ._register import register_receiver
+from ._base import Base
+from ._names import ReceiverName
+
+
+@dataclasses.dataclass(frozen=True)
+class _Mode:
+    FIXED_CENTER_FREQUENCY = "fixed_center_frequency"
+
+
+@register_receiver(ReceiverName.RX888MK2)
+class RX888MK2(Base):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.add_mode(
+            _Mode.FIXED_CENTER_FREQUENCY,
+            spectre_server.core.models.RX888MK2FixedCenterFrequency,
+            spectre_server.core.flowgraphs.RX888MK2FixedCenterFrequency,
+            spectre_server.core.events.FixedCenterFrequency,
+            spectre_server.core.batches.IQStreamBatch,
+        )

--- a/backend/tests/unit/core/test_receivers.py
+++ b/backend/tests/unit/core/test_receivers.py
@@ -141,6 +141,7 @@ class TestReceivers:
             spectre_server.core.receivers.ReceiverName.HACKRF,
             spectre_server.core.receivers.ReceiverName.HACKRFONE,
             spectre_server.core.receivers.ReceiverName.RTLSDR,
+            spectre_server.core.receivers.ReceiverName.RX888MK2,
         ],
     )
     def test_construction(self, receiver_name: str) -> None:
@@ -159,6 +160,7 @@ class TestReceivers:
             spectre_server.core.receivers.ReceiverName.HACKRF,
             spectre_server.core.receivers.ReceiverName.HACKRFONE,
             spectre_server.core.receivers.ReceiverName.RTLSDR,
+            spectre_server.core.receivers.ReceiverName.RX888MK2,
         ],
     )
     def test_write_default_config(

--- a/backend/tests/unit/services/test_receivers.py
+++ b/backend/tests/unit/services/test_receivers.py
@@ -20,4 +20,5 @@ def test_get_receivers() -> None:
         "hackrfone",
         "rtlsdr",
         "rsp1b",
+        "rx888mk2",
     ]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install .
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.3.3-alpha" \
+      version="3.4.0-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 
@@ -57,7 +57,7 @@ USER appuser
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.3.3-alpha" \
+      version="3.4.0-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-cli"
-version = "3.3.3-alpha"
+version = "3.4.0-alpha"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jimmy@spectregrams.org" },
 ]

--- a/cli/src/spectre_cli/__init__.py
+++ b/cli/src/spectre_cli/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "3.3.3-alpha"
+__version__ = "3.4.0-alpha"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   spectre-server:
     container_name: spectre-server
-    image: spectregrams/spectre-server:3.3.3-alpha
+    image: spectregrams/spectre-server:3.4.0-alpha
     environment:
       - SPECTRE_GID=${SPECTRE_GID}
       - SPECTRE_BIND_HOST=${SPECTRE_BIND_HOST}
@@ -20,7 +20,7 @@ services:
 
   spectre-cli:
     container_name: spectre-cli
-    image: spectregrams/spectre-cli:3.3.3-alpha
+    image: spectregrams/spectre-cli:3.4.0-alpha
     environment:
       - SPECTRE_SERVER_HOST=${SPECTRE_SERVER_HOST}
       - SPECTRE_SERVER_PORT=${SPECTRE_SERVER_PORT}

--- a/setup.sh
+++ b/setup.sh
@@ -40,6 +40,8 @@ echo "Writing udev rules to $UDEV_FILE"
     echo "SUBSYSTEM==\"usb\", ENV{ID_VENDOR_ID}==\"1d50\", MODE=\"0660\", GROUP=\"$SPECTRE_GROUP\""
     echo '# RTL-SDR'
     echo "SUBSYSTEM==\"usb\", ENV{ID_VENDOR_ID}==\"0bda\", MODE=\"0660\", GROUP=\"$SPECTRE_GROUP\""
+    echo '# SDDC'
+    echo "SUBSYSTEM==\"usb\", ENV{ID_VENDOR_ID}==\"04b4\", MODE=\"0660\", GROUP=\"$SPECTRE_GROUP\""
 } > "$UDEV_FILE"
 
 # Apply the new udev rules.


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Provides basic support for the [RX-888 MK II](https://www.rx-888.com/rx/) using the [Soapy SDDC](https://github.com/ik1xpv/ExtIO_sddc) plugin. One mode is added where the device operates at a fixed centre frequency. For the time being, only the HF antenna port is supported.

## Issue link
<!-- Add the link to the related issue(s) -->
[issue-219](https://github.com/spectregrams/spectre/issues/219)

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Each commit represents a single, coherent unit of work
- [X] My changes are covered by unit tests
- [X] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
