### PR TITLE
feat: issue-234 RX-888 MK II support on `linux/arm64`

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -351,13 +351,10 @@ WORKDIR /tmp
 
 ARG TARGETARCH
 
-# TODO: At the time of writing, there's nothing to pin since the [latest tag](https://github.com/ik1xpv/ExtIO_sddc/releases/tag/v1.2.0) 
-# does not provide the Soapy plugin. A stable fork is used instead, for consistent builds. Revisit this when we can pin the version from the 
-# official repository.
-# NOTE: ExtIO_sddc does not yet compile on linux/arm64, so we can't support devices that use it on that platform.
-# An empty directory is created as a placeholder, so the COPY instruction to the runtime target doesn't fail.
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-    git clone --depth 1 https://github.com/spectregrams/ExtIO_sddc && \
+# Use a custom fork with a patch providing support for the RX-888 MK II on the platform `linux/arm64`.
+# See PR: (https://github.com/ik1xpv/ExtIO_sddc/pull/246).
+# TODO: Buld ExtIO_sddc from an official branch.
+RUN git clone --depth 1 -b v0.0.1 https://github.com/spectregrams/ExtIO_sddc && \
     cd ExtIO_sddc && \
     mkdir build && \
     cd build && \
@@ -366,10 +363,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
           .. && \
     make -j"$(nproc)" && \
     make install && \
-    rm -rf /tmp/*; \
-    else \
-    mkdir -p /opt/soapy_sddc/lib; \
-    fi
+    rm -rf /tmp/*
 
 # --------------------------------------------- #
 # Shared build dependencies for OOT modules.
@@ -451,7 +445,7 @@ COPY gunicorn.conf.py /opt/spectre_server/
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.4.3-alpha" \
+      version="3.5.0-alpha" \
       description="Docker image for running the `spectre-server`." \
       license="GPL-3.0-or-later"
 
@@ -536,7 +530,7 @@ CMD ["/app/cmd.sh"]
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.4.3-alpha" \
+      version="3.5.0-alpha" \
       description="Docker image for  developing the `spectre-server`." \
       license="GPL-3.0-or-later"
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-server"
-version = "3.4.3-alpha"
+version = "3.5.0-alpha"
 authors = [
   { name = "Jimmy Fitzpatrick", email = "jimmy@spectregrams.org" }
 ]

--- a/backend/src/spectre_server/__init__.py
+++ b/backend/src/spectre_server/__init__.py
@@ -2,6 +2,6 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "3.4.3-alpha"
+__version__ = "3.5.0-alpha"
 
 __all__ = ["core", "routes", "services"]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install .
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.4.3-alpha" \
+      version="3.5.0-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 
@@ -57,7 +57,7 @@ USER appuser
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.4.3-alpha" \
+      version="3.5.0-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-cli"
-version = "3.4.3-alpha"
+version = "3.5.0-alpha"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jimmy@spectregrams.org" },
 ]

--- a/cli/src/spectre_cli/__init__.py
+++ b/cli/src/spectre_cli/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "3.4.3-alpha"
+__version__ = "3.5.0-alpha"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   spectre-server:
     container_name: spectre-server
-    image: spectregrams/spectre-server:3.4.3-alpha
+    image: spectregrams/spectre-server:3.5.0-alpha
     environment:
       - SPECTRE_GID=${SPECTRE_GID}
       - SPECTRE_BIND_HOST=${SPECTRE_BIND_HOST}
@@ -20,7 +20,7 @@ services:
 
   spectre-cli:
     container_name: spectre-cli
-    image: spectregrams/spectre-cli:3.4.3-alpha
+    image: spectregrams/spectre-cli:3.5.0-alpha
     environment:
       - SPECTRE_SERVER_HOST=${SPECTRE_SERVER_HOST}
       - SPECTRE_SERVER_PORT=${SPECTRE_SERVER_PORT}


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Provides support for the RX-888 MK II on the platform `linux/arm64`, notably, Raspberry Pi's. This is done by picking up a patch on the [Spectregrams fork](https://github.com/spectregrams/ExtIO_sddc) of the `ExtIO_sddc` drivers. 

At the time of writing, the patch is submitted as a contribution [here](https://github.com/ik1xpv/ExtIO_sddc/pull/246), and we can swap back to an official branch if it is accepted. Otherwise, we can continue maintaining the fork.

## Issue link
<!-- Add the link to the related issue(s) -->
[issue-234](https://github.com/spectregrams/spectre/issues/234)

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [X] My changes are covered by unit tests
- [X] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
