### PR TITLE
fix: issue-239 Resolve RX-888 MK II dropping samples

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -445,7 +445,7 @@ COPY gunicorn.conf.py /opt/spectre_server/
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.5.0-alpha" \
+      version="3.5.1-alpha" \
       description="Docker image for running the `spectre-server`." \
       license="GPL-3.0-or-later"
 
@@ -530,7 +530,7 @@ CMD ["/app/cmd.sh"]
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.5.0-alpha" \
+      version="3.5.1-alpha" \
       description="Docker image for  developing the `spectre-server`." \
       license="GPL-3.0-or-later"
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -354,7 +354,7 @@ ARG TARGETARCH
 # Use a custom fork with a patch providing support for the RX-888 MK II on the platform `linux/arm64`.
 # See PR: (https://github.com/ik1xpv/ExtIO_sddc/pull/246).
 # TODO: Buld ExtIO_sddc from an official branch.
-RUN git clone --depth 1 -b v0.0.1 https://github.com/spectregrams/ExtIO_sddc && \
+RUN git clone --depth 1 -b v0.0.2 https://github.com/spectregrams/ExtIO_sddc && \
     cd ExtIO_sddc && \
     mkdir build && \
     cd build && \

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-server"
-version = "3.5.0-alpha"
+version = "3.5.1-alpha"
 authors = [
   { name = "Jimmy Fitzpatrick", email = "jimmy@spectregrams.org" }
 ]

--- a/backend/src/spectre_server/__init__.py
+++ b/backend/src/spectre_server/__init__.py
@@ -2,6 +2,6 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "3.5.0-alpha"
+__version__ = "3.5.1-alpha"
 
 __all__ = ["core", "routes", "services"]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install .
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.5.0-alpha" \
+      version="3.5.1-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 
@@ -57,7 +57,7 @@ USER appuser
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.5.0-alpha" \
+      version="3.5.1-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-cli"
-version = "3.5.0-alpha"
+version = "3.5.1-alpha"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jimmy@spectregrams.org" },
 ]

--- a/cli/src/spectre_cli/__init__.py
+++ b/cli/src/spectre_cli/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "3.5.0-alpha"
+__version__ = "3.5.1-alpha"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   spectre-server:
     container_name: spectre-server
-    image: spectregrams/spectre-server:3.5.0-alpha
+    image: spectregrams/spectre-server:3.5.1-alpha
     environment:
       - SPECTRE_GID=${SPECTRE_GID}
       - SPECTRE_BIND_HOST=${SPECTRE_BIND_HOST}
@@ -20,7 +20,7 @@ services:
 
   spectre-cli:
     container_name: spectre-cli
-    image: spectregrams/spectre-cli:3.5.0-alpha
+    image: spectregrams/spectre-cli:3.5.1-alpha
     environment:
       - SPECTRE_SERVER_HOST=${SPECTRE_SERVER_HOST}
       - SPECTRE_SERVER_PORT=${SPECTRE_SERVER_PORT}


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
Picks up a fix in our fork of [ExtIO_sddc](https://github.com/spectregrams/ExtIO_sddc), which resolves the RX-888 MK II dropping samples at runtime. Now, the timestamps of each recording produced in that mode are aligned with wall time.

## Issue link
<!-- Add the link to the related issue(s) -->
[issue-239](https://github.com/spectregrams/spectre/issues/239)
[issue-240](https://github.com/spectregrams/spectre/issues/240)

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [ ] My changes are covered by unit tests
- [X] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
