### PR TITLE
fix: issue-209 Properly record number of samples between tags during frequency sweeps

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -552,7 +552,7 @@ COPY --from=volk /opt/volk/include /usr/include
 COPY --from=gnuradio /opt/gnuradio/include /usr/include
 
 # Get the latest version of `spectre-server`, overriding that from the `runtime` stage.
-RUN git clone https://github.com/robrui/spectre.git -b fix/hdr-uint64-counts --no-checkout && cd spectre && \
+RUN git clone https://github.com/spectregrams/spectre.git --no-checkout && cd spectre && \
     git sparse-checkout init --no-cone && \
     git sparse-checkout set backend/ && \
     git checkout && \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -409,7 +409,7 @@ RUN . ./build_oot_module.sh && \
 FROM oot_module AS gr_spectre
 
 RUN . ./build_oot_module.sh && \
-    build_from_repo https://github.com/spectregrams/gr-spectre.git v2.1.1 && \
+    build_from_repo https://github.com/spectregrams/gr-spectre.git v2.1.2 && \
     rm -rf /tmp/*
 
 
@@ -445,7 +445,7 @@ COPY gunicorn.conf.py /opt/spectre_server/
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.5.1-alpha" \
+      version="3.5.2-alpha" \
       description="Docker image for running the `spectre-server`." \
       license="GPL-3.0-or-later"
 
@@ -530,7 +530,7 @@ CMD ["/app/cmd.sh"]
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.5.1-alpha" \
+      version="3.5.2-alpha" \
       description="Docker image for  developing the `spectre-server`." \
       license="GPL-3.0-or-later"
 
@@ -552,7 +552,7 @@ COPY --from=volk /opt/volk/include /usr/include
 COPY --from=gnuradio /opt/gnuradio/include /usr/include
 
 # Get the latest version of `spectre-server`, overriding that from the `runtime` stage.
-RUN git clone https://github.com/spectregrams/spectre.git --no-checkout && cd spectre && \
+RUN git clone https://github.com/robrui/spectre.git -b fix/hdr-uint64-counts --no-checkout && cd spectre && \
     git sparse-checkout init --no-cone && \
     git sparse-checkout set backend/ && \
     git checkout && \

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-server"
-version = "3.5.1-alpha"
+version = "3.5.2-alpha"
 authors = [
   { name = "Jimmy Fitzpatrick", email = "jimmy@spectregrams.org" }
 ]

--- a/backend/src/spectre_server/__init__.py
+++ b/backend/src/spectre_server/__init__.py
@@ -2,6 +2,6 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "3.5.1-alpha"
+__version__ = "3.5.2-alpha"
 
 __all__ = ["core", "routes", "services"]

--- a/backend/src/spectre_server/core/batches/_iq_stream.py
+++ b/backend/src/spectre_server/core/batches/_iq_stream.py
@@ -86,7 +86,7 @@ class IQMetadata:
     """
 
     center_frequencies: npt.NDArray[np.float32]
-    num_samples: npt.NDArray[np.int32]
+    num_samples: npt.NDArray[np.int64]
 
 
 class _HdrFile(BatchFile[IQMetadata]):
@@ -96,8 +96,15 @@ class _HdrFile(BatchFile[IQMetadata]):
 
         :return: A container for the metadata
         """
-        data = np.fromfile(self.file_path, dtype=np.float32)
-        return IQMetadata(data[0::2], data[1::2].astype(np.int32))
+        # The binary layout is [value_float32, nsamples_uint64] repeated (12 bytes per entry).
+        raw = np.fromfile(self.file_path, dtype=np.uint8)
+        entry_bytes = 12
+        n_entries = raw.size // entry_bytes
+        raw = raw[:n_entries * entry_bytes]
+
+        values = np.frombuffer(raw.tobytes(), dtype=np.float32, count=n_entries, offset=0)
+        nsamples = np.frombuffer(raw.tobytes(), dtype=np.uint64, count=n_entries, offset=4)
+        return IQMetadata(values, nsamples.astype(np.int64))
 
 
 class _FitsFile(BatchFile[spectre_server.core.spectrograms.Spectrogram]):

--- a/backend/src/spectre_server/core/batches/_iq_stream.py
+++ b/backend/src/spectre_server/core/batches/_iq_stream.py
@@ -100,11 +100,11 @@ class _HdrFile(BatchFile[IQMetadata]):
         raw = np.fromfile(self.file_path, dtype=np.uint8)
         entry_bytes = 12
         n_entries = raw.size // entry_bytes
-        raw = raw[:n_entries * entry_bytes]
+        raw = raw[: n_entries * entry_bytes]
 
-        dt = np.dtype([('value', '<f4'), ('nsamples', '<u8')])
+        dt = np.dtype([("value", "<f4"), ("nsamples", "<u8")])
         structured = np.frombuffer(raw.tobytes(), dtype=dt)
-        return IQMetadata(structured['value'], structured['nsamples'].astype(np.int64))
+        return IQMetadata(structured["value"], structured["nsamples"].astype(np.int64))
 
 
 class _FitsFile(BatchFile[spectre_server.core.spectrograms.Spectrogram]):

--- a/backend/src/spectre_server/core/batches/_iq_stream.py
+++ b/backend/src/spectre_server/core/batches/_iq_stream.py
@@ -102,9 +102,9 @@ class _HdrFile(BatchFile[IQMetadata]):
         n_entries = raw.size // entry_bytes
         raw = raw[:n_entries * entry_bytes]
 
-        values = np.frombuffer(raw.tobytes(), dtype=np.float32, count=n_entries, offset=0)
-        nsamples = np.frombuffer(raw.tobytes(), dtype=np.uint64, count=n_entries, offset=4)
-        return IQMetadata(values, nsamples.astype(np.int64))
+        dt = np.dtype([('value', '<f4'), ('nsamples', '<u8')])
+        structured = np.frombuffer(raw.tobytes(), dtype=dt)
+        return IQMetadata(structured['value'], structured['nsamples'].astype(np.int64))
 
 
 class _FitsFile(BatchFile[spectre_server.core.spectrograms.Spectrogram]):

--- a/backend/src/spectre_server/core/batches/_iq_stream.py
+++ b/backend/src/spectre_server/core/batches/_iq_stream.py
@@ -86,7 +86,7 @@ class IQMetadata:
     """
 
     center_frequencies: npt.NDArray[np.float32]
-    num_samples: npt.NDArray[np.int64]
+    num_samples: npt.NDArray[np.uint64]
 
 
 class _HdrFile(BatchFile[IQMetadata]):
@@ -96,15 +96,9 @@ class _HdrFile(BatchFile[IQMetadata]):
 
         :return: A container for the metadata
         """
-        # The binary layout is [value_float32, nsamples_uint64] repeated (12 bytes per entry).
-        raw = np.fromfile(self.file_path, dtype=np.uint8)
-        entry_bytes = 12
-        n_entries = raw.size // entry_bytes
-        raw = raw[: n_entries * entry_bytes]
-
-        dt = np.dtype([("value", "<f4"), ("nsamples", "<u8")])
-        structured = np.frombuffer(raw.tobytes(), dtype=dt)
-        return IQMetadata(structured["value"], structured["nsamples"].astype(np.int64))
+        dt = np.dtype([("value", np.float32), ("num_samples", np.uint64)])
+        metadata = np.fromfile(self.file_path, dtype=dt)
+        return IQMetadata(metadata["value"], metadata["num_samples"])
 
 
 class _FitsFile(BatchFile[spectre_server.core.spectrograms.Spectrogram]):

--- a/backend/src/spectre_server/core/events/_swept_center_frequency.py
+++ b/backend/src/spectre_server/core/events/_swept_center_frequency.py
@@ -43,7 +43,7 @@ def _average_over_steps(
 
 
 def _compute_num_max_frames_in_step(
-    num_samples: npt.NDArray[np.int32], window_size: int, window_hop: int
+    num_samples: npt.NDArray[np.int64], window_size: int, window_hop: int
 ) -> int:
     """Compute the maximum number of frames for all steps, and all sweeps, in the batch."""
     return get_num_spectrums(int(np.max(num_samples)), window_size, window_hop)
@@ -101,7 +101,7 @@ def _compute_stepped_dynamic_spectra(
     window_hop: int,
     num_full_sweeps: int,
     num_steps_per_sweep: int,
-    num_samples: npt.NDArray[np.int32],
+    num_samples: npt.NDArray[np.int64],
 ) -> None:
     """For each full sweep, compute execute a short-time discrete Fourier transform on the IQ samples for each step."""
     # Store the step index over all sweeps (doesn't reset each sweep).
@@ -159,7 +159,7 @@ def _compute_frequencies(
 
 def _compute_times(
     times: npt.NDArray[np.float32],
-    num_samples: npt.NDArray[np.int32],
+    num_samples: npt.NDArray[np.int64],
     sample_rate: float,
     num_full_sweeps: int,
     num_steps_per_sweep: int,
@@ -188,7 +188,7 @@ def _swept_stfft(
     sample_rate: float,
     frequency_hop: float,
     center_frequencies: npt.NDArray[np.float32],
-    num_samples: npt.NDArray[np.int32],
+    num_samples: npt.NDArray[np.int64],
 ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.float32]]:
     _validate_center_frequencies_ordering(center_frequencies, frequency_hop)
 
@@ -239,10 +239,10 @@ def _swept_stfft(
 
 
 def _prepend_num_samples(
-    carryover_num_samples: npt.NDArray[np.int32],
-    num_samples: npt.NDArray[np.int32],
+    carryover_num_samples: npt.NDArray[np.int64],
+    num_samples: npt.NDArray[np.int64],
     final_step_spans_two_batches: bool,
-) -> npt.NDArray[np.int32]:
+) -> npt.NDArray[np.int64]:
     """Prepend the number of samples from the final sweep of the previous batch, to the first
     sweep of the current batch."""
     if final_step_spans_two_batches:
@@ -278,7 +278,7 @@ def _prepend_iq_data(
 def _get_final_sweep(
     previous_iq_data: npt.NDArray[np.complex64],
     previous_iq_metadata: spectre_server.core.batches.IQMetadata,
-) -> tuple[npt.NDArray[np.complex64], npt.NDArray[np.float32], npt.NDArray[np.int32]]:
+) -> tuple[npt.NDArray[np.complex64], npt.NDArray[np.float32], npt.NDArray[np.int64]]:
     """Get IQ samples and metadata from the final sweep of the previous batch."""
 
     if (
@@ -322,7 +322,7 @@ def _reconstruct_initial_sweep(
     iq_data: npt.NDArray[np.complex64],
     iq_metadata: spectre_server.core.batches.IQMetadata,
 ) -> tuple[
-    npt.NDArray[np.complex64], npt.NDArray[np.float32], npt.NDArray[np.int32], int
+    npt.NDArray[np.complex64], npt.NDArray[np.float32], npt.NDArray[np.int64], int
 ]:
     """Reconstruct the initial sweep of the current batch, using data from the previous batch.
 

--- a/backend/src/spectre_server/core/events/_swept_center_frequency.py
+++ b/backend/src/spectre_server/core/events/_swept_center_frequency.py
@@ -176,7 +176,7 @@ def _compute_times(
         end_step = (sweep_index + 1) * num_steps_per_sweep
 
         # Update cumulative samples
-        cumulative_samples += np.sum(num_samples[start_step:end_step])
+        cumulative_samples += int(np.sum(num_samples[start_step:end_step]))
 
 
 def _swept_stfft(

--- a/backend/src/spectre_server/core/events/_swept_center_frequency.py
+++ b/backend/src/spectre_server/core/events/_swept_center_frequency.py
@@ -43,7 +43,7 @@ def _average_over_steps(
 
 
 def _compute_num_max_frames_in_step(
-    num_samples: npt.NDArray[np.int64], window_size: int, window_hop: int
+    num_samples: npt.NDArray[np.uint64], window_size: int, window_hop: int
 ) -> int:
     """Compute the maximum number of frames for all steps, and all sweeps, in the batch."""
     return get_num_spectrums(int(np.max(num_samples)), window_size, window_hop)
@@ -101,7 +101,7 @@ def _compute_stepped_dynamic_spectra(
     window_hop: int,
     num_full_sweeps: int,
     num_steps_per_sweep: int,
-    num_samples: npt.NDArray[np.int64],
+    num_samples: npt.NDArray[np.uint64],
 ) -> None:
     """For each full sweep, compute execute a short-time discrete Fourier transform on the IQ samples for each step."""
     # Store the step index over all sweeps (doesn't reset each sweep).
@@ -113,12 +113,11 @@ def _compute_stepped_dynamic_spectra(
         for step_index in range(num_steps_per_sweep):
 
             # Extract how many samples are in the current step from the metadata.
-            end_sample_index = start_sample_index + num_samples[global_step_index]
+            samples_in_step = int(num_samples[global_step_index])
+            end_sample_index = start_sample_index + samples_in_step
 
             # Compute the number of frames we can squeeze into the current step.
-            num_frames = get_num_spectrums(
-                num_samples[global_step_index], window.size, window_hop
-            )
+            num_frames = get_num_spectrums(samples_in_step, window.size, window_hop)
 
             # Execute a short time discrete fourier transform on the step, then shift the
             # zero-frequency component to the middle of the spectrum.
@@ -159,7 +158,7 @@ def _compute_frequencies(
 
 def _compute_times(
     times: npt.NDArray[np.float32],
-    num_samples: npt.NDArray[np.int64],
+    num_samples: npt.NDArray[np.uint64],
     sample_rate: float,
     num_full_sweeps: int,
     num_steps_per_sweep: int,
@@ -188,7 +187,7 @@ def _swept_stfft(
     sample_rate: float,
     frequency_hop: float,
     center_frequencies: npt.NDArray[np.float32],
-    num_samples: npt.NDArray[np.int64],
+    num_samples: npt.NDArray[np.uint64],
 ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.float32]]:
     _validate_center_frequencies_ordering(center_frequencies, frequency_hop)
 
@@ -239,10 +238,10 @@ def _swept_stfft(
 
 
 def _prepend_num_samples(
-    carryover_num_samples: npt.NDArray[np.int64],
-    num_samples: npt.NDArray[np.int64],
+    carryover_num_samples: npt.NDArray[np.uint64],
+    num_samples: npt.NDArray[np.uint64],
     final_step_spans_two_batches: bool,
-) -> npt.NDArray[np.int64]:
+) -> npt.NDArray[np.uint64]:
     """Prepend the number of samples from the final sweep of the previous batch, to the first
     sweep of the current batch."""
     if final_step_spans_two_batches:
@@ -278,7 +277,7 @@ def _prepend_iq_data(
 def _get_final_sweep(
     previous_iq_data: npt.NDArray[np.complex64],
     previous_iq_metadata: spectre_server.core.batches.IQMetadata,
-) -> tuple[npt.NDArray[np.complex64], npt.NDArray[np.float32], npt.NDArray[np.int64]]:
+) -> tuple[npt.NDArray[np.complex64], npt.NDArray[np.float32], npt.NDArray[np.uint64]]:
     """Get IQ samples and metadata from the final sweep of the previous batch."""
 
     if (
@@ -301,14 +300,15 @@ def _get_final_sweep(
         final_sweep_start_step_index:
     ]
     final_num_samples = previous_iq_metadata.num_samples[final_sweep_start_step_index:]
-    final_iq_data = previous_iq_data[-np.sum(final_num_samples) :]
+    final_iq_data = previous_iq_data[-int(np.sum(final_num_samples, dtype=np.uint64)) :]
 
     # Do a sanity check on the number of samples in the final sweep
-    if len(final_iq_data) != np.sum(final_num_samples):
+    expected_num_samples = int(np.sum(final_num_samples))
+    if len(final_iq_data) != expected_num_samples:
         raise ValueError(
             (
                 f"Unexpected error! Mismatch in sample count for the final sweep data."
-                f"Expected {np.sum(final_num_samples)} based on sweep metadata, but found "
+                f"Expected {expected_num_samples} based on sweep metadata, but found "
                 f" {len(final_iq_data)} IQ samples in the final sweep"
             )
         )
@@ -322,7 +322,7 @@ def _reconstruct_initial_sweep(
     iq_data: npt.NDArray[np.complex64],
     iq_metadata: spectre_server.core.batches.IQMetadata,
 ) -> tuple[
-    npt.NDArray[np.complex64], npt.NDArray[np.float32], npt.NDArray[np.int64], int
+    npt.NDArray[np.complex64], npt.NDArray[np.float32], npt.NDArray[np.uint64], int
 ]:
     """Reconstruct the initial sweep of the current batch, using data from the previous batch.
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install .
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.5.1-alpha" \
+      version="3.5.2-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 
@@ -57,7 +57,7 @@ USER appuser
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="3.5.1-alpha" \
+      version="3.5.2-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-cli"
-version = "3.5.1-alpha"
+version = "3.5.2-alpha"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jimmy@spectregrams.org" },
 ]

--- a/cli/src/spectre_cli/__init__.py
+++ b/cli/src/spectre_cli/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "3.5.1-alpha"
+__version__ = "3.5.2-alpha"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   spectre-server:
     container_name: spectre-server
-    image: spectregrams/spectre-server:3.5.1-alpha
+    image: spectregrams/spectre-server:3.5.2-alpha
     environment:
       - SPECTRE_GID=${SPECTRE_GID}
       - SPECTRE_BIND_HOST=${SPECTRE_BIND_HOST}
@@ -20,7 +20,7 @@ services:
 
   spectre-cli:
     container_name: spectre-cli
-    image: spectregrams/spectre-cli:3.5.1-alpha
+    image: spectregrams/spectre-cli:3.5.2-alpha
     environment:
       - SPECTRE_SERVER_HOST=${SPECTRE_SERVER_HOST}
       - SPECTRE_SERVER_PORT=${SPECTRE_SERVER_PORT}


### PR DESCRIPTION
## What does this PR do?

Update the _HdrFile reader to parse the new binary format where sample counts are stored as uint64_t instead of float32.

The initial implementation used `np.frombuffer` with `offset=` which reads continuously through the buffer, ignoring the 12-byte entry boundary. Fixed to use a structured `np.dtype` so each `[value_float32, nsamples_uint64]` entry is parsed correctly.

## Issue link

https://github.com/spectregrams/spectre/issues/209

## Checklist before merging

- [ ] My commit history follows the conventional commits specification
- [x] Each commit represents a single, coherent unit of work
- [ ] My changes are covered by unit tests
- [ ] Unit tests successfully run locally
- [x] I have formatted Python code with black
- [x] I have checked static type hinting with mypy
- [ ] I have added/updated necessary documentation, if required
- [x] I have checked for and resolved any merge conflicts
- [x] I have performed a self-review of my code

## Additional notes

Companion to spectregrams/gr-spectre#24 which fixes the float32 overflow in the batched file sink. A local test script (3 cases: normal values, large sample count >2^24, extra bytes truncation) was verified against the new reader logic. The full pytest suite requires hardware-specific GNU Radio modules (gnuradio.sdrplay3) which are not available in the test environment.