### PR TITLE
feat: issue-221 Add the `callisto` mode to the `rx888mk2`

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -445,7 +445,7 @@ COPY gunicorn.conf.py /opt/spectre_server/
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="4.0.0-alpha" \
+      version="4.1.0-alpha" \
       description="Docker image for running the `spectre-server`." \
       license="GPL-3.0-or-later"
 
@@ -530,7 +530,7 @@ CMD ["/app/cmd.sh"]
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="4.0.0-alpha" \
+      version="4.1.0-alpha" \
       description="Docker image for  developing the `spectre-server`." \
       license="GPL-3.0-or-later"
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-server"
-version = "4.0.0-alpha"
+version = "4.1.0-alpha"
 authors = [
   { name = "Jimmy Fitzpatrick", email = "jimmy@spectregrams.org" }
 ]

--- a/backend/src/spectre_server/__init__.py
+++ b/backend/src/spectre_server/__init__.py
@@ -2,6 +2,6 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "4.0.0-alpha"
+__version__ = "4.1.0-alpha"
 
 __all__ = ["core", "routes", "services"]

--- a/backend/src/spectre_server/core/batches/__init__.py
+++ b/backend/src/spectre_server/core/batches/__init__.py
@@ -13,6 +13,12 @@ from ._base import (
 )
 from ._batches import Batches
 from ._iq_stream import IQMetadata, IQStreamBatch, IQStreamBatchExtension
+from ._callisto import (
+    CallistoBatch,
+    CallistoBatchExtension,
+    callisto_digits_to_linear,
+    callisto_digits_from_linear,
+)
 
 __all__ = [
     "Base",
@@ -24,4 +30,8 @@ __all__ = [
     "IQMetadata",
     "IQStreamBatch",
     "IQStreamBatchExtension",
+    "CallistoBatch",
+    "CallistoBatchExtension",
+    "callisto_digits_to_linear",
+    "callisto_digits_from_linear",
 ]

--- a/backend/src/spectre_server/core/batches/_callisto.py
+++ b/backend/src/spectre_server/core/batches/_callisto.py
@@ -36,8 +36,7 @@ def callisto_digits_from_linear(
     # detector and ADC.
     digits = ((db * DETECTOR_CONVERSION_RATE) / ADC_VOLTAGE_RANGE) * ADC_DIGIT_RANGE
 
-    # Round to nearest ADC code before casting to avoid float32 truncation artifacts
-    # (e.g. 0.9999999 becoming 0).
+    # Avoid float32 truncation artifacts (e.g. 0.9999999 becoming 0).
     digits = np.rint(digits)
 
     # Cast to unsigned 8-bit integers, clipping to avoid overflows.

--- a/backend/src/spectre_server/core/batches/_callisto.py
+++ b/backend/src/spectre_server/core/batches/_callisto.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: © 2024-2026 Jimmy Fitzpatrick <jimmy@spectregrams.org>
+# This file is part of SPECTRE
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import dataclasses
+import datetime
+import os
+import typing
+
+import numpy as np
+import numpy.typing as npt
+import astropy.io.fits
+
+import spectre_server.core.spectrograms
+
+from ._base import Base, BatchFile
+
+ADC_DIGIT_RANGE = np.float32(255)  # [1]
+ADC_VOLTAGE_RANGE = np.float32(2500)  # [mV]
+DETECTOR_CONVERSION_RATE = np.float32(25.4)  # [mv/dB]
+MIN_LINEAR_AMPLITUDE = np.finfo(np.float32).tiny
+
+
+def callisto_digits_from_linear(
+    dynamic_spectra: npt.NDArray[np.float32],
+) -> npt.NDArray[np.uint8]:
+    """Transform from linearised CALLISTO digits back to digits.
+
+    NOTE: The narrowing conversion introduces quantisation errors, but that's unavoidable since
+    we must preserve compatibility with e-Callisto FITS files whose primary
+    data array (effectively) encodes 8-bit unsigned integers.
+    """
+    # Values in (0, 1) are valid (negative dB), but non-positive values are undefined for log10.
+    db = 10 * np.log10(np.maximum(dynamic_spectra, MIN_LINEAR_AMPLITUDE))
+    # Transform the dB values to ADC digits, using hardware specifications from CALLISTO's logarithmic
+    # detector and ADC.
+    digits = ((db * DETECTOR_CONVERSION_RATE) / ADC_VOLTAGE_RANGE) * ADC_DIGIT_RANGE
+
+    # Round to nearest ADC code before casting to avoid float32 truncation artifacts
+    # (e.g. 0.9999999 becoming 0).
+    digits = np.rint(digits)
+
+    # Cast to unsigned 8-bit integers, clipping to avoid overflows.
+    min_digit, max_digit = 0, 255
+    return np.clip(digits, min_digit, max_digit).astype(dtype=np.uint8)
+
+
+def callisto_digits_to_linear(
+    digits: npt.NDArray[np.uint8],
+) -> npt.NDArray[np.float32]:
+    """Linearise CALLISTO ADC digits.
+
+    NOTE: The widening conversion to float32 is required for compatibility with Spectre -
+    dynamic spectra arrays use dtype np.float32.
+    """
+    db = (digits.astype(np.float32) / ADC_DIGIT_RANGE) * (
+        ADC_VOLTAGE_RANGE / DETECTOR_CONVERSION_RATE
+    )
+    return 10 ** (db / 10)
+
+
+@dataclasses.dataclass(frozen=True)
+class CallistoBatchExtension:
+    """Supported extensions for a `CallistoBatch`.
+
+    :ivar FIT: Corresponds to the `.fit` file extension.
+    :ivar FC32: Corresponds to the `.fc32` file extension.
+    """
+
+    FIT: str = "fit"
+    FC32: str = "fc32"
+
+
+class _Fc32File(BatchFile[npt.NDArray[np.complex64]]):
+    def read(self) -> npt.NDArray[np.complex64]:
+        """Read single-precision complex, interleaved I/Q samples in the binary format.
+
+        :return: 64-bit complex IQ samples.
+        """
+        return np.fromfile(self.file_path, dtype=np.complex64)
+
+
+class _FitFile(BatchFile[spectre_server.core.spectrograms.Spectrogram]):
+
+    def read(self) -> spectre_server.core.spectrograms.Spectrogram:
+        """Read the FIT file and create a spectrogram."""
+        with astropy.io.fits.open(self.file_path, mode="readonly") as hdulist:
+            primary_hdu = hdulist[0]
+            bintable_hdu = hdulist[1]
+
+            # e-Callisto stores the times and frequencies as double precision floating points,
+            # so cast back to single precision. No concern for this narrowing conversion,
+            # since the values started as single-precision anyway before being written to disk.
+            times = np.asarray(bintable_hdu.data["TIME"][0], dtype=np.float32)
+
+            # Same narrowing conversion, but also reverse the frequencies (e-Callisto stores them backwards) and convert from MHz to Hz.
+            frequencies = (
+                np.asarray(bintable_hdu.data["FREQUENCY"][0], dtype=np.float32)[::-1]
+                * 1e6
+            )
+
+            linearised_digits = callisto_digits_to_linear(primary_hdu.data)
+
+            return spectre_server.core.spectrograms.Spectrogram(
+                # Reverse each spectrum in the spectrogram (as with the frequencies, e-Callisto stores them backwards).
+                linearised_digits[::-1, :],
+                times,
+                frequencies,
+                spectre_server.core.spectrograms.SpectrumUnit.CALLISTO,
+                self.start_datetime,
+            )
+
+
+class CallistoBatch(Base):
+
+    def __init__(self, batches_dir_path: str, start_time: str, tag: str) -> None:
+        """A batch containing spectrograms compatible with the e-Callisto network.
+
+        Supports the following extensions:
+        - `.fit`
+        - `.fc32`
+
+        :param batches_dir_path: The shared parent directory for each batch file.
+        :param start_time: The start time of the batch.
+        :param tag: The batch name tag.
+        """
+        super().__init__(batches_dir_path, start_time, tag)
+
+        self.add_file(_FitFile, CallistoBatchExtension.FIT)
+        self.add_file(_Fc32File, CallistoBatchExtension.FC32)
+
+    @property
+    def fit_file(self) -> _FitFile:
+        """The batch file corresponding to the `.fit` extension."""
+        return typing.cast(_FitFile, self.get_file(CallistoBatchExtension.FIT))
+
+    @property
+    def fc32_file(self) -> _Fc32File:
+        """The batch file corresponding to the `.fc32` extension."""
+        return typing.cast(_Fc32File, self.get_file(CallistoBatchExtension.FC32))
+
+    @property
+    def spectrogram_file(self) -> _FitFile:
+        return self.fit_file
+
+    def read_iq(self, extension: str) -> npt.NDArray[np.complex64]:
+        """Read I/Q samples from the batch."""
+        if extension == CallistoBatchExtension.FC32:
+            return self.fc32_file.read()
+        else:
+            raise ValueError(f"Unsupported output type: {extension}")
+
+    def delete_iq(self, extension: str) -> None:
+        """Delete I/Q samples from the batch."""
+        if extension == CallistoBatchExtension.FC32:
+            self.fc32_file.delete()
+
+    def write_spectrogram(
+        self,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+        origin: str,
+        instrume: str,
+        observer: str,
+        object_: str,
+        telescop: str,
+        obsgeo_b: float,
+        obsgeo_l: float,
+        obsgeo_h: float,
+    ) -> None:
+        """Write spectrogram data to disk compatible with the e-Callisto network."""
+
+        digits = callisto_digits_from_linear(spectrogram.dynamic_spectra)
+
+        # Create the primary HDU (the basic keywords are set by Astropy).
+        # Reverse each spectrum in the spectrogram (as with the frequencies, e-Callisto stores them backwards).
+        primary_hdu = astropy.io.fits.PrimaryHDU(data=digits[::-1, :])
+
+        # All data in the batch should have the same start time.
+        if self.start_datetime != spectrogram.start_datetime.astype(datetime.datetime):
+            raise ValueError(
+                "Start time of the spectrogram must coincide with the start time of the batch. "
+                f"Expected: {self.start_datetime}. Got: {spectrogram.start_datetime}."
+            )
+
+        start_datetime = spectrogram.datetimes[0].astype(datetime.datetime)
+        end_datetime = spectrogram.datetimes[-1].astype(datetime.datetime)
+
+        date = datetime.datetime.strftime(start_datetime, "%Y-%m-%d")
+        date_obs = datetime.datetime.strftime(start_datetime, "%Y/%m/%d")
+        date_end = datetime.datetime.strftime(end_datetime, "%Y/%m/%d")
+        time_obs = datetime.datetime.strftime(start_datetime, "%H:%M:%S.%f")[:-3]
+        time_end = datetime.datetime.strftime(end_datetime, "%H:%M:%S")
+
+        primary_hdu.header.set("DATE", date)
+        primary_hdu.header.set("ORIGIN", origin)
+        primary_hdu.header.set("TELESCOP", telescop)
+        primary_hdu.header.set("INSTRUME", instrume)
+        primary_hdu.header.set("OBSERVER", observer)
+        primary_hdu.header.set("OBJECT", object_)
+
+        primary_hdu.header.set("BZERO", 0)
+        primary_hdu.header.set("BSCALE", 1)
+        primary_hdu.header.set("DATAMIN", int(np.nanmin(primary_hdu.data)))
+        primary_hdu.header.set("DATAMAX", int(np.nanmax(primary_hdu.data)))
+        primary_hdu.header.set("BUNIT", "digits")
+
+        primary_hdu.header.set("DATE-OBS", date_obs)
+        primary_hdu.header.set("DATE-END", date_end)
+        primary_hdu.header.set("TIME-OBS", time_obs)
+        primary_hdu.header.set("TIME-END", time_end)
+
+        # ----------------------------------------------------------------------- #
+        # In the e-Callisto FITS files, the values assumed by the world coordinate
+        # system keywords don't appear to be consistent with the data in the binary
+        # table extension or the spectrogram. We prioritise making them consistent
+        # with e-Callisto, rather than the FITS standard.
+        # ----------------------------------------------------------------------- #
+        seconds_since_midnight = (
+            start_datetime.hour * 3600
+            + start_datetime.minute * 60
+            + start_datetime.second
+        )
+        primary_hdu.header.set("CRVAL1", seconds_since_midnight)
+        primary_hdu.header.set("CRPIX1", 0)
+        primary_hdu.header.set("CTYPE1", "Time [UT]")
+        primary_hdu.header.set("CDELT1", spectrogram.time_resolution)
+        primary_hdu.header.set("CRVAL2", 200)
+        primary_hdu.header.set("CRPIX2", 0)
+        primary_hdu.header.set("CRTYPE2", "Frequency [MHz]")
+        primary_hdu.header.set("CDELT2", -1)
+
+        primary_hdu.header.set("OBS_LAT", obsgeo_b)
+        primary_hdu.header.set("OBS_LAC", "N")
+        primary_hdu.header.set("OBS_LON", obsgeo_l)
+        primary_hdu.header.set("OBS_LOC", "E")
+        primary_hdu.header.set("OBS_ALT", obsgeo_h)
+        primary_hdu.header.set(
+            "CONTENT",
+            f"{date_obs}  Radio flux density, e-CALLISTO ({instrume})",
+        )
+        # These keywords do not carry over in any meaningful way, so set them to empty.
+        primary_hdu.header.set("FRQFILE", "")
+        primary_hdu.header.set("PWM_VAL", "")
+
+        bintable_hdu = astropy.io.fits.BinTableHDU.from_columns(
+            [
+                astropy.io.fits.Column(
+                    name="TIME",
+                    format=f"{spectrogram.num_times}D8.3",
+                    array=[spectrogram.times.astype(np.float64)],
+                ),
+                astropy.io.fits.Column(
+                    name="FREQUENCY",
+                    format=f"{spectrogram.num_frequencies}D8.3",
+                    # Reverse, and convert to MHz.
+                    array=[spectrogram.frequencies.astype(np.float64)[::-1] * 1e-6],
+                ),
+            ]
+        )
+        bintable_hdu.header.set("TSCAL1", 1)
+        bintable_hdu.header.set("TSCAL2", 1)
+        bintable_hdu.header.set("TZERO1", 0)
+        bintable_hdu.header.set("TZERO2", 0)
+
+        os.makedirs(self.fit_file.parent_dir_path, exist_ok=True)
+        astropy.io.fits.HDUList([primary_hdu, bintable_hdu]).writeto(
+            self.fit_file.file_path,
+            overwrite=True,
+        )

--- a/backend/src/spectre_server/core/batches/_callisto.py
+++ b/backend/src/spectre_server/core/batches/_callisto.py
@@ -154,6 +154,8 @@ class CallistoBatch(Base):
         """Delete I/Q samples from the batch."""
         if extension == CallistoBatchExtension.FC32:
             self.fc32_file.delete()
+        else:
+            raise ValueError(f"Unsupported output type: {extension}")
 
     def write_spectrogram(
         self,

--- a/backend/src/spectre_server/core/events/__init__.py
+++ b/backend/src/spectre_server/core/events/__init__.py
@@ -7,6 +7,7 @@
 from ._base import Base
 from ._fixed_center_frequency import FixedCenterFrequency, FixedCenterFrequencyModel
 from ._swept_center_frequency import SweptCenterFrequency, SweptCenterFrequencyModel
+from ._callisto import Callisto, CallistoModel
 
 from ._stfft import (
     stfft,
@@ -25,6 +26,8 @@ __all__ = [
     "FixedCenterFrequencyModel",
     "SweptCenterFrequency",
     "SweptCenterFrequencyModel",
+    "Callisto",
+    "CallistoModel",
     "stfft",
     "get_buffer",
     "get_window",

--- a/backend/src/spectre_server/core/events/_callisto.py
+++ b/backend/src/spectre_server/core/events/_callisto.py
@@ -85,7 +85,7 @@ class Callisto(Base[CallistoModel, spectre_server.core.batches.CallistoBatch]):
     def process(
         self, batch: spectre_server.core.batches.CallistoBatch
     ) -> spectre_server.core.spectrograms.Spectrogram:
-        """TBD."""
+        """Create a CALLISTO-compatible spectrogram from a batch of IQ samples."""
         _LOGGER.info(f"Reading the I/Q samples")
         iq_data = batch.read_iq(self.__model.output_type)
 

--- a/backend/src/spectre_server/core/events/_callisto.py
+++ b/backend/src/spectre_server/core/events/_callisto.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: © 2024-2026 Jimmy Fitzpatrick <jimmy@spectregrams.org>
+# This file is part of SPECTRE
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
+import typing
+
+import numpy as np
+import numpy.typing as npt
+
+import spectre_server.core.fields
+import spectre_server.core.batches
+
+from ._base import Base, BaseModel
+from ._stfft import (
+    get_buffer,
+    get_window,
+    get_times,
+    get_num_spectrums,
+    get_frequencies,
+    get_fftw_obj,
+    stfft,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CallistoModel(BaseModel):
+    window_size: spectre_server.core.fields.Field.window_size = 1024
+    window_hop: spectre_server.core.fields.Field.window_hop = 1024
+    window_type: spectre_server.core.fields.Field.window_type = (
+        spectre_server.core.fields.WindowType.BLACKMAN
+    )
+    center_frequency: spectre_server.core.fields.Field.center_frequency = 95.8e6
+    sample_rate: spectre_server.core.fields.Field.sample_rate = 32e3
+    frequency_resolution: spectre_server.core.fields.Field.frequency_resolution = 0
+    time_resolution: spectre_server.core.fields.Field.time_resolution = 0
+    batch_size: spectre_server.core.fields.Field.batch_size = 3
+    keep_signal: spectre_server.core.fields.Field.keep_signal = True
+    output_type: spectre_server.core.fields.Field.output_type = (
+        spectre_server.core.fields.OutputType.FC32
+    )
+    callisto_scale_factor: spectre_server.core.fields.Field.callisto_scale_factor = 1
+
+
+def __linear_calibration(
+    dynamic_spectra: npt.NDArray[np.float32], gradient: float, const: float = 0
+) -> npt.NDArray[np.float32]:
+    """Apply a calibration relating DFT amplitudes to linearised CALLISTO digits.
+
+    This assumes (of course) that the relationship is linear, and also (more subtly)
+    that the relationship is independent of frequency.
+    """
+    return dynamic_spectra * gradient + const
+
+
+class Callisto(Base[CallistoModel, spectre_server.core.batches.CallistoBatch]):
+    def __init__(
+        self,
+        tag: str,
+        model: CallistoModel,
+        batch_cls: typing.Type[spectre_server.core.batches.CallistoBatch],
+    ) -> None:
+        super().__init__(tag, model, batch_cls)
+        self.__model = model
+
+        # Make the window.
+        self.__window = get_window(self.__model.window_type, self.__model.window_size)
+
+        # Pre-allocate the buffer.
+        self.__buffer = get_buffer(self.__model.window_size)
+
+        # Defer the expensive FFTW plan creation until the first batch is being processed.
+        # With this approach, we avoid a bug where filesystem events are missed because
+        # the watchdog observer isn't set up in time before the receiver starts capturing data.
+        self.__fftw_obj = None
+
+    @property
+    def _watch_extension(self) -> str:
+        return self.__model.output_type
+
+    def process(
+        self, batch: spectre_server.core.batches.CallistoBatch
+    ) -> spectre_server.core.spectrograms.Spectrogram:
+        """TBD."""
+        _LOGGER.info(f"Reading the I/Q samples")
+        iq_data = batch.read_iq(self.__model.output_type)
+
+        if self.__fftw_obj is None:
+            _LOGGER.info(f"Creating the FFTW plan")
+            self.__fftw_obj = get_fftw_obj(self.__buffer)
+
+        _LOGGER.info("Executing the short-time FFT")
+        dynamic_spectra = stfft(
+            self.__fftw_obj,
+            self.__buffer,
+            iq_data,
+            self.__window,
+            self.__model.window_hop,
+        )
+
+        # Compute the physical times we'll assign to each spectrum.
+        num_spectrums = get_num_spectrums(
+            iq_data.size, self.__model.window_size, self.__model.window_hop
+        )
+        times = get_times(
+            num_spectrums, self.__model.sample_rate, self.__model.window_hop
+        )
+
+        # Get the physical frequencies assigned to each spectral component, shift the zero frequency to the middle of the
+        # spectrum, then translate the array up from the baseband.
+        frequencies = (
+            np.fft.fftshift(
+                get_frequencies(self.__model.window_size, self.__model.sample_rate)
+            )
+            + self.__model.center_frequency
+        )
+
+        # Shift the zero-frequency component to the middle of the spectrum.
+        dynamic_spectra = np.fft.fftshift(dynamic_spectra, axes=0)
+
+        linearised_digits = __linear_calibration(
+            dynamic_spectra, self.__model.callisto_scale_factor
+        )
+
+        _LOGGER.info("Creating the spectrogram")
+        spectrogram = spectre_server.core.spectrograms.Spectrogram(
+            linearised_digits,
+            times,
+            frequencies,
+            spectre_server.core.spectrograms.SpectrumUnit.CALLISTO,
+            batch.start_datetime,
+        )
+
+        spectrogram = spectre_server.core.spectrograms.time_average(
+            spectrogram, max(self.__model.time_resolution, spectrogram.time_resolution)
+        )
+        spectrogram = spectre_server.core.spectrograms.frequency_average(
+            spectrogram,
+            max(self.__model.frequency_resolution, spectrogram.frequency_resolution),
+        )
+
+        _LOGGER.info("Spectrogram created successfully")
+
+        if not self.__model.keep_signal:
+            _LOGGER.info(f"Deleting the I/Q samples")
+            batch.delete_iq(self.__model.output_type)
+
+        return spectrogram

--- a/backend/src/spectre_server/core/events/_callisto.py
+++ b/backend/src/spectre_server/core/events/_callisto.py
@@ -40,10 +40,13 @@ class CallistoModel(BaseModel):
     output_type: spectre_server.core.fields.Field.output_type = (
         spectre_server.core.fields.OutputType.FC32
     )
-    callisto_scale_factor: spectre_server.core.fields.Field.callisto_scale_factor = 1
+    # Default value is provided by Alexandro Rabadán Parra, see https://github.com/AlexandroRP99/e-Callisto_Py_RX-888_MK_II
+    callisto_scale_factor: spectre_server.core.fields.Field.callisto_scale_factor = (
+        89958.629068
+    )
 
 
-def __linear_calibration(
+def linear_calibration(
     dynamic_spectra: npt.NDArray[np.float32], gradient: float, const: float = 0
 ) -> npt.NDArray[np.float32]:
     """Apply a calibration relating DFT amplitudes to linearised CALLISTO digits.
@@ -119,7 +122,7 @@ class Callisto(Base[CallistoModel, spectre_server.core.batches.CallistoBatch]):
         # Shift the zero-frequency component to the middle of the spectrum.
         dynamic_spectra = np.fft.fftshift(dynamic_spectra, axes=0)
 
-        linearised_digits = __linear_calibration(
+        linearised_digits = linear_calibration(
             dynamic_spectra, self.__model.callisto_scale_factor
         )
 

--- a/backend/src/spectre_server/core/fields/_fields.py
+++ b/backend/src/spectre_server/core/fields/_fields.py
@@ -354,6 +354,6 @@ class Field:
         pydantic.Field(
             ...,
             validate_default=True,
-            description="A scale factor that transforms DFT amplitudes to linearised CALLISTO digits.",
+            description="Transform DFT amplitudes to linearised CALLISTO receiver digits through a linear calibration.",
         ),
     ]

--- a/backend/src/spectre_server/core/fields/_fields.py
+++ b/backend/src/spectre_server/core/fields/_fields.py
@@ -349,3 +349,11 @@ class Field:
             description="The variable-gain amplifier gain, in dB.",
         ),
     ]
+    callisto_scale_factor = typing.Annotated[
+        float,
+        pydantic.Field(
+            ...,
+            validate_default=True,
+            description="A scale factor that transforms DFT amplitudes to linearised CALLISTO digits.",
+        ),
+    ]

--- a/backend/src/spectre_server/core/models/__init__.py
+++ b/backend/src/spectre_server/core/models/__init__.py
@@ -18,7 +18,7 @@ from ._b200mini import B200miniFixedCenterFrequency, B200miniSweptCenterFrequenc
 from ._hackrf import HackRFFixedCenterFrequency
 from ._hackrfone import HackRFOneFixedCenterFrequency
 from ._rtlsdr import RTLSDRFixedCenterFrequency
-from ._rx888mk2 import RX888MK2FixedCenterFrequency
+from ._rx888mk2 import RX888MK2FixedCenterFrequency, RX888MK2Callisto
 
 __all__ = [
     "SignalGeneratorCosineWaveModel",
@@ -38,4 +38,5 @@ __all__ = [
     "HackRFOneFixedCenterFrequency",
     "RTLSDRFixedCenterFrequency",
     "RX888MK2FixedCenterFrequency",
+    "RX888MK2Callisto",
 ]

--- a/backend/src/spectre_server/core/models/_rx888mk2.py
+++ b/backend/src/spectre_server/core/models/_rx888mk2.py
@@ -10,6 +10,7 @@ import spectre_server.core.flowgraphs
 from ._validators import (
     skip_validator,
     validate_window_size,
+    validate_window_type,
     validate_in_range,
     validate_one_of,
 )
@@ -34,6 +35,47 @@ class RX888MK2FixedCenterFrequency(
         if skip_validator(info):
             return self
         validate_window_size(self.window_size)
+        validate_output_type(self.output_type)
+
+        if not self.antenna_port == spectre_server.core.flowgraphs.RX888MK2Port.HF:
+            raise ValueError(
+                f"Only the HF port is currently supported. Got {self.antenna_port}"
+            )
+
+        validate_in_range(
+            self.center_frequency,
+            lower_bound=HF_FREQ_LOWER_BOUND,
+            upper_bound=HF_FREQ_UPPER_BOUND,
+            name="center_frequency",
+        )
+        validate_in_range(
+            self.rf_gain,
+            lower_bound=RF_GAIN_LOWER_BOUND,
+            upper_bound=RF_GAIN_UPPER_BOUND,
+            name="rf_gain",
+        )
+        validate_in_range(
+            self.if_gain,
+            lower_bound=IF_GAIN_LOWER_BOUND,
+            upper_bound=IF_GAIN_UPPER_BOUND,
+            name="if_gain",
+        )
+        validate_one_of(self.sample_rate, HF_ALLOWED_SAMPLE_RATES, "sample_rate")
+        validate_one_of(self.output_type, EXPECTED_OUTPUT_TYPES, "output_type")
+        return self
+
+
+class RX888MK2Callisto(
+    # Reuse the flowgraph from the `fixed_center_frequency` mode.
+    spectre_server.core.flowgraphs.RX888MK2FixedCenterFrequencyModel,
+    spectre_server.core.events.CallistoModel,
+):
+    @pydantic.model_validator(mode="after")
+    def validator(self, info: pydantic.ValidationInfo):
+        if skip_validator(info):
+            return self
+        validate_window_size(self.window_size)
+        validate_window_type(self.window_type)
         validate_output_type(self.output_type)
 
         if not self.antenna_port == spectre_server.core.flowgraphs.RX888MK2Port.HF:

--- a/backend/src/spectre_server/core/receivers/_rx888mk2.py
+++ b/backend/src/spectre_server/core/receivers/_rx888mk2.py
@@ -17,6 +17,7 @@ from ._names import ReceiverName
 @dataclasses.dataclass(frozen=True)
 class _Mode:
     FIXED_CENTER_FREQUENCY = "fixed_center_frequency"
+    CALLISTO = "callisto"
 
 
 @register_receiver(ReceiverName.RX888MK2)
@@ -30,4 +31,13 @@ class RX888MK2(Base):
             spectre_server.core.flowgraphs.RX888MK2FixedCenterFrequency,
             spectre_server.core.events.FixedCenterFrequency,
             spectre_server.core.batches.IQStreamBatch,
+        )
+
+        self.add_mode(
+            _Mode.CALLISTO,
+            spectre_server.core.models.RX888MK2Callisto,
+            # Reuse the flowgraph from the `fixed_center_frequency` mode.
+            spectre_server.core.flowgraphs.RX888MK2FixedCenterFrequency,
+            spectre_server.core.events.Callisto,
+            spectre_server.core.batches.CallistoBatch,
         )

--- a/backend/src/spectre_server/core/spectrograms/_spectrogram.py
+++ b/backend/src/spectre_server/core/spectrograms/_spectrogram.py
@@ -26,9 +26,11 @@ class SpectrumUnit(enum.Enum):
     """A defined unit for dynamic spectra values.
 
     :ivar AMPLITUDE: DFT amplitude (see https://www.fftw.org/fftw3_doc/What-FFTW-Really-Computes.html)
+    :ivar CALLISTO: Linearised callisto digits.
     """
 
     AMPLITUDE = "amplitude"
+    CALLISTO = "callisto"
 
 
 @dataclasses.dataclass
@@ -272,7 +274,7 @@ class Spectrogram:
         background_spectra = background_spectrum[:, np.newaxis]
         # Suppress divide by zero and invalid value warnings for this block of code
         with np.errstate(divide="ignore", invalid="ignore"):
-            if self._spectrum_unit == SpectrumUnit.AMPLITUDE:
+            if self._spectrum_unit in [SpectrumUnit.AMPLITUDE, SpectrumUnit.CALLISTO]:
                 dynamic_spectra_dBb = 10 * np.log10(
                     self._dynamic_spectra / background_spectra
                 )

--- a/backend/tests/unit/core/test_batches.py
+++ b/backend/tests/unit/core/test_batches.py
@@ -761,10 +761,6 @@ class TestCallistoBatch:
             assert bintable_hdu.header.get("TZERO2") == 0
             assert bintable_hdu.header.get("NAXIS1") == 4 * 8 + 6 * 8
             assert bintable_hdu.header.get("NAXIS2") == 1
-
-            # ----------------------------------------------------------------------- #
-            # Conformal keywords that do not assume conformal values.
-            # ----------------------------------------------------------------------- #
             # The .3 are e-Callisto conventions.
             assert bintable_hdu.header.get("TFORM1") == "6D8.3"
             assert bintable_hdu.header.get("TFORM2") == "4D8.3"

--- a/backend/tests/unit/core/test_batches.py
+++ b/backend/tests/unit/core/test_batches.py
@@ -23,7 +23,7 @@ OBSERVER = "jimmy@spectregrams.org"
 OBSGEO_B = -4.3342366
 OBSGEO_L = 55.7726726
 OBSGEO_H = 138
-TEST_START = datetime.datetime(year=2000, month=1, day=1, hour=0, minute=0, second=0)
+TEST_START = datetime.datetime(year=2000, month=1, day=25, hour=1, minute=0, second=0)
 
 
 @pytest.fixture
@@ -115,8 +115,8 @@ def spectrogram() -> spectre_server.core.spectrograms.Spectrogram:
         ],
         dtype=np.float32,
     )
-    times = np.array([0.00, 0.20, 0.40, 0.60, 0.80, 1.0])
-    frequencies = np.array([1e6, 2e6, 3e6, 4e6])
+    times = np.array([0.00, 0.20, 0.40, 0.60, 0.80, 1.0], dtype=np.float32)
+    frequencies = np.array([1e6, 2e6, 3e6, 4e6], dtype=np.float32)
     return spectre_server.core.spectrograms.Spectrogram(
         dynamic_spectra,
         times,
@@ -175,12 +175,30 @@ def iqstream_batch(
     )
 
 
+@pytest.fixture
+def callisto_batch(
+    spectre_config_paths: spectre_server.core.config.Paths,
+) -> spectre_server.core.batches.CallistoBatch:
+    batches_dir_path = spectre_config_paths.get_batches_dir_path(
+        TEST_START.year,
+        TEST_START.month,
+        TEST_START.day,
+    )
+    return spectre_server.core.batches.CallistoBatch(
+        batches_dir_path,
+        datetime.datetime.strftime(
+            TEST_START, spectre_server.core.config.TimeFormat.DATETIME
+        ),
+        TAG,
+    )
+
+
 @pytest.mark.parametrize(
     "file_name, parsed_file_name",
     [
         (
-            "2025-06-01T00:00:00.000000Z_tag.ext",
-            ("2025-06-01T00:00:00.000000Z", "tag", "ext"),
+            "2025-06-01T01:00:00.000000Z_tag.ext",
+            ("2025-06-01T01:00:00.000000Z", "tag", "ext"),
         ),  # Happy path.
     ],
 )
@@ -195,8 +213,8 @@ def test_parse_batch_file_name(
 @pytest.mark.parametrize(
     "file_name",
     [
-        "2025-06-01T00:00:00.000000Z.ext",  # No tag
-        "2025-06-01T00:00:00.000000Z_bad_tag.ext",  # Multiple underscores.
+        "2025-06-01T01:00:00.000000Z.ext",  # No tag
+        "2025-06-01T01:00:00.000000Z_bad_tag.ext",  # Multiple underscores.
     ],
 )
 def test_parse_batch_file_name_invalid_underscores(file_name: str) -> None:
@@ -214,45 +232,45 @@ class TestBatches:
                 -1,
                 4,
                 [
-                    "2000-01-01T00:00:00.000000Z_tag",
-                    "2000-01-01T00:00:01.000000Z_tag",
-                    "2000-01-01T00:00:02.000000Z_tag",
+                    "2000-01-25T01:00:00.000000Z_tag",
+                    "2000-01-25T01:00:01.000000Z_tag",
+                    "2000-01-25T01:00:02.000000Z_tag",
                 ],
             ),
             (
                 0,
                 3,
                 [
-                    "2000-01-01T00:00:00.000000Z_tag",
-                    "2000-01-01T00:00:01.000000Z_tag",
-                    "2000-01-01T00:00:02.000000Z_tag",
+                    "2000-01-25T01:00:00.000000Z_tag",
+                    "2000-01-25T01:00:01.000000Z_tag",
+                    "2000-01-25T01:00:02.000000Z_tag",
                 ],
             ),
             # Range includes only the first batch.
-            (0, 0.0001, ["2000-01-01T00:00:00.000000Z_tag"]),
-            (0, 0.9999, ["2000-01-01T00:00:00.000000Z_tag"]),
+            (0, 0.0001, ["2000-01-25T01:00:00.000000Z_tag"]),
+            (0, 0.9999, ["2000-01-25T01:00:00.000000Z_tag"]),
             # Range includes only the middle batch.
-            (1, 1.0001, ["2000-01-01T00:00:01.000000Z_tag"]),
-            (1, 1.9999, ["2000-01-01T00:00:01.000000Z_tag"]),
+            (1, 1.0001, ["2000-01-25T01:00:01.000000Z_tag"]),
+            (1, 1.9999, ["2000-01-25T01:00:01.000000Z_tag"]),
             # Range includes only the last batch.
-            (2, 2.0001, ["2000-01-01T00:00:02.000000Z_tag"]),
-            (2, 2.9999, ["2000-01-01T00:00:02.000000Z_tag"]),
+            (2, 2.0001, ["2000-01-25T01:00:02.000000Z_tag"]),
+            (2, 2.9999, ["2000-01-25T01:00:02.000000Z_tag"]),
             # Range includes first two batches.
             (
                 0,
                 1.5,
-                ["2000-01-01T00:00:00.000000Z_tag", "2000-01-01T00:00:01.000000Z_tag"],
+                ["2000-01-25T01:00:00.000000Z_tag", "2000-01-25T01:00:01.000000Z_tag"],
             ),
             # Range includes last two batches.
             (
                 1,
                 3,
-                ["2000-01-01T00:00:01.000000Z_tag", "2000-01-01T00:00:02.000000Z_tag"],
+                ["2000-01-25T01:00:01.000000Z_tag", "2000-01-25T01:00:02.000000Z_tag"],
             ),
             # Range before all batches
             (-10, -1, []),
             # Range after all batches (final batch has an indeterminate end)
-            (10, 20, ["2000-01-01T00:00:02.000000Z_tag"]),
+            (10, 20, ["2000-01-25T01:00:02.000000Z_tag"]),
         ],
     )
     def test_get_batches_in_range(
@@ -428,7 +446,7 @@ class TestIQStreamBatch:
             obsgeo_h=OBSGEO_H,
         )
 
-        # Check the spectrogram we wrote to disk, is consistent with what we read back.
+        # Check the spectrogram we wrote to disk is consistent with what we read back.
         s = iqstream_batch.read_spectrogram()
         assert np.array_equal(s.dynamic_spectra, spectrogram.dynamic_spectra)
 
@@ -451,16 +469,16 @@ class TestIQStreamBatch:
             # assert "END" in primary_hdu.header.keys()
 
             # Keywords representing time.
-            assert primary_hdu.header.get("DATE") == "2000-01-01T00:00:00.000000"
-            assert primary_hdu.header.get("DATE-OBS") == "2000-01-01T00:00:00.000000"
+            assert primary_hdu.header.get("DATE") == "2000-01-25T01:00:00.000000"
+            assert primary_hdu.header.get("DATE-OBS") == "2000-01-25T01:00:00.000000"
             assert primary_hdu.header.get("TIMESYS") == "UTC"
             assert primary_hdu.header.get("TREFPOS") == "TOPOCENTER"
             assert primary_hdu.header.get("OBSGEO-B") == OBSGEO_B
             assert primary_hdu.header.get("OBSGEO-L") == OBSGEO_L
             assert primary_hdu.header.get("OBSGEO-H") == OBSGEO_H
-            assert primary_hdu.header.get("DATEREF") == "2000-01-01T00:00:00.000000"
-            assert primary_hdu.header.get("DATE-BEG") == "2000-01-01T00:00:00.000000"
-            assert primary_hdu.header.get("DATE-END") == "2000-01-01T00:00:01.000000"
+            assert primary_hdu.header.get("DATEREF") == "2000-01-25T01:00:00.000000"
+            assert primary_hdu.header.get("DATE-BEG") == "2000-01-25T01:00:00.000000"
+            assert primary_hdu.header.get("DATE-END") == "2000-01-25T01:00:01.000000"
 
             # General descriptive keywords.
             assert primary_hdu.header.get("ORIGIN") == ORIGIN
@@ -486,13 +504,13 @@ class TestIQStreamBatch:
             assert primary_hdu.header.get("CUNIT1") == "s"
             assert primary_hdu.header.get("CRPIX1") == 1.0
             assert primary_hdu.header.get("CRVAL1") == 0.0
-            assert primary_hdu.header.get("CDELT1") == 0.2
+            assert np.isclose(primary_hdu.header.get("CDELT1"), 0.2)
 
             assert primary_hdu.header.get("CTYPE2") == "FREQ"
             assert primary_hdu.header.get("CUNIT2") == "Hz"
             assert primary_hdu.header.get("CRPIX2") == 1.0
             assert primary_hdu.header.get("CRVAL2") == 1e6
-            assert primary_hdu.header.get("CDELT2") == 1e6
+            assert np.isclose(primary_hdu.header.get("CDELT2"), 1e6)
 
             assert primary_hdu.header.get("PC1_1") == 1.0
             assert primary_hdu.header.get("PC2_2") == 1.0
@@ -507,7 +525,246 @@ class TestIQStreamBatch:
             wcs = astropy.wcs.WCS(primary_hdu.header, fix=False)
 
             # Check the four world coordinates at extremal indices (1-indexed, by convention in the standard)
-            assert np.array_equal(wcs.wcs_pix2world([[1, 1]], 1), [[0.0, 1e6]])
-            assert np.array_equal(wcs.wcs_pix2world([[1, 4]], 1), [[0.0, 4e6]])
-            assert np.array_equal(wcs.wcs_pix2world([[6, 1]], 1), [[1.0, 1e6]])
-            assert np.array_equal(wcs.wcs_pix2world([[6, 4]], 1), [[1.0, 4e6]])
+            assert np.allclose(wcs.wcs_pix2world([[1, 1]], 1), [[0.0, 1e6]])
+            assert np.allclose(wcs.wcs_pix2world([[1, 4]], 1), [[0.0, 4e6]])
+            assert np.allclose(wcs.wcs_pix2world([[6, 1]], 1), [[1.0, 1e6]])
+            assert np.allclose(wcs.wcs_pix2world([[6, 4]], 1), [[1.0, 4e6]])
+
+
+class TestCallistoBatch:
+    def test_callisto_digits_from_linear_no_underflow(
+        self,
+    ) -> None:
+        """Check that small values don't underflow when they're transformed to CALLISTO digits."""
+        dynamic_spectra = np.array([-1, 0, 0.5, 1, 2, 3], dtype=np.float32)
+        expected = np.array([0, 0, 0, 0, 8, 12], dtype=np.uint8)
+        assert np.array_equal(
+            spectre_server.core.batches.callisto_digits_from_linear(dynamic_spectra),
+            expected,
+        )
+
+    def test_callisto_digits_from_linear_no_overflow(
+        self,
+    ) -> None:
+        """Check that large values don't overflow when they're transformed to CALLISTO digits."""
+        # The big value and delta were found empircally.
+        big_value, delta = 6958566400, 5e8
+        just_under, just_over = big_value - delta, big_value + delta
+        very_over = big_value * 2
+        dynamic_spectra = np.array(
+            [just_under, big_value, just_over, very_over],
+            dtype=np.float32,
+        )
+        expected = np.array([254, 255, 255, 255], dtype=np.uint8)
+        assert np.array_equal(
+            spectre_server.core.batches.callisto_digits_from_linear(dynamic_spectra),
+            expected,
+        )
+
+    def test_callisto_digits_from_linear_typical(self) -> None:
+        """Check a typical value correctly transforms to a CALLISTO digit."""
+        # The expected value is computed by hand.
+        dynamic_spectra = np.array([3.470352815], dtype=np.float32)
+        expected = np.array([14], dtype=np.uint8)
+        assert np.array_equal(
+            spectre_server.core.batches.callisto_digits_from_linear(dynamic_spectra),
+            expected,
+        )
+
+    def test_callisto_digits_to_linear_min(
+        self,
+    ) -> None:
+        """Check that the minimum possible CALLISTO digit is correctly transformed to unity when linearised."""
+        digits = np.array([0], dtype=np.uint8)
+        expected = np.float32(1)
+        assert (
+            spectre_server.core.batches.callisto_digits_to_linear(digits)[0] == expected
+        )
+
+    def test_callisto_digits_to_linear_max(
+        self,
+    ) -> None:
+        """Check that the maximum possible CALLISTO digit is correctly transformed to the maximum value when linearised."""
+        digits = np.array([255], dtype=np.uint8)
+        expected = np.float32(6958566400)
+        assert np.isclose(
+            spectre_server.core.batches.callisto_digits_to_linear(digits)[0],
+            expected,
+        )
+
+    def test_callisto_digits_to_linear_typical(
+        self,
+    ) -> None:
+        """Check that a typical digit is correctly transformed when linearised."""
+        # The expected value is computed by hand.
+        digits = np.array([14], dtype=np.uint8)
+        expected = np.float32(3.470352815)
+        assert np.isclose(
+            spectre_server.core.batches.callisto_digits_to_linear(digits)[0], expected
+        )
+
+    def test_round_trip_from_callisto_digits(
+        self,
+    ) -> None:
+        """Check that CALLISTO digits are preserved transforming to and from the linear scale."""
+        digits = np.arange(255, dtype=np.uint8)
+        assert np.array_equal(
+            digits,
+            spectre_server.core.batches.callisto_digits_from_linear(
+                spectre_server.core.batches.callisto_digits_to_linear(digits)
+            ),
+        )
+
+    def test_round_trip_from_linear(
+        self,
+    ) -> None:
+        """Explicitly recognise a round trip is _not_ possible starting from linear values,
+        due to floating point precision loss and quantisation errors."""
+        # The range of values was chosen arbitrarily, we just have to stick to positive values.
+        linear = np.arange(100, dtype=np.float32)
+        assert not np.allclose(
+            linear,
+            spectre_server.core.batches.callisto_digits_to_linear(
+                spectre_server.core.batches.callisto_digits_from_linear(linear)
+            ),
+        )
+
+    def test_write_and_read_spectrogram(
+        self,
+        callisto_batch: spectre_server.core.batches.CallistoBatch,
+        spectrogram: spectre_server.core.spectrograms.Spectrogram,
+    ) -> None:
+        """Spectrograms written to disk must conform to e-Callisto FITS conventions,
+        and be consistent with the spectrogram read back.
+        """
+
+        # Write the spectrogram to disk.
+        callisto_batch.write_spectrogram(
+            spectrogram,
+            origin=ORIGIN,
+            instrume=INSTRUME,
+            observer=OBSERVER,
+            object_=OBJECT,
+            telescop=TELESCOP,
+            obsgeo_b=OBSGEO_B,
+            obsgeo_l=OBSGEO_L,
+            obsgeo_h=OBSGEO_H,
+        )
+
+        # Check the spectrogram we wrote to disk is consistent with what we read back.
+        # A full round trip is _not_ possible starting from linear values due to floating point precision loss
+        # and quantisation errors during the transformation. So, check a few of the values are close, up to a tolerance.
+        s = callisto_batch.read_spectrogram()
+        assert np.allclose(s.dynamic_spectra, spectrogram.dynamic_spectra, atol=1)
+
+        # Should be bitwise equal, since this is read from the binary table extension.
+        assert np.array_equal(s.times, spectrogram.times)
+        assert np.array_equal(s.frequencies, spectrogram.frequencies)
+
+        # Check the FITS file conforms to e-Callisto conventions.
+        with astropy.io.fits.open(callisto_batch.fit_file.file_path) as hdulist:
+
+            # First, check the keywords in the primary HDU.
+            primary_hdu: astropy.io.fits.PrimaryHDU = hdulist[0]
+
+            # ----------------------------------------------- #
+            # Conformal keywords that assume conformal values.
+            # ----------------------------------------------- #
+            assert primary_hdu.header.get("SIMPLE") == True
+            assert primary_hdu.header.get("BITPIX") == 8
+            assert primary_hdu.header.get("NAXIS") == 2
+            assert primary_hdu.header.get("NAXIS1") == 6
+            assert primary_hdu.header.get("NAXIS2") == 4
+            assert primary_hdu.header.get("EXTEND") == True
+            assert primary_hdu.header.get("DATE") == "2000-01-25"
+            assert primary_hdu.header.get("ORIGIN") == ORIGIN
+            assert primary_hdu.header.get("TELESCOP") == TELESCOP
+            assert primary_hdu.header.get("INSTRUME") == INSTRUME
+            assert primary_hdu.header.get("OBJECT") == OBJECT
+            assert primary_hdu.header.get("BZERO") == 0
+            assert primary_hdu.header.get("BSCALE") == 1
+            assert primary_hdu.header.get("DATAMIN") == 0
+            assert primary_hdu.header.get("DATAMAX") == 35
+            # Not reccommended (the value should conform with the recommendations in the IAU Style Manual), but this is conformal.
+            assert primary_hdu.header.get("BUNIT") == "digits"
+
+            # ----------------------------------------------------------------------- #
+            # Conformal keywords that do not assume conformal values.
+            #
+            # Keyword records are retained for consistency with e-Callisto FITS files.
+            # ----------------------------------------------------------------------- #
+            # Non-conformal due to invalid date format.
+            assert primary_hdu.header.get("DATE-OBS") == "2000/01/25"
+            assert primary_hdu.header.get("DATE-END") == "2000/01/25"
+
+            # ----------------------------------------------------------------------- #
+            # Non-conformal keywords.
+            #
+            # Keyword records are retained for consistency with e-Callisto FITS files.
+            # ----------------------------------------------------------------------- #
+            # Values are retained for consistency with e-Callisto FITS files.
+            assert (
+                primary_hdu.header.get("CONTENT")
+                == f"{primary_hdu.header.get('DATE-OBS')}  Radio flux density, e-CALLISTO ({primary_hdu.header.get('INSTRUME')})"
+            )
+            # Exactly three digits to the fractional component is intentional.
+            assert primary_hdu.header.get("TIME-OBS") == "01:00:00.000"
+            # No fractional component is intentional.
+            assert primary_hdu.header.get("TIME-END") == "01:00:01"
+            assert primary_hdu.header.get("OBS_LAT") == OBSGEO_B
+            assert primary_hdu.header.get("OBS_LAC") == "N"
+            assert primary_hdu.header.get("OBS_LON") == OBSGEO_L
+            assert primary_hdu.header.get("OBS_LOC") == "E"
+            assert primary_hdu.header.get("OBS_ALT") == OBSGEO_H
+            # Empty values are intentional - these keyword records don't carry over in any meaningful way.
+            assert primary_hdu.header.get("FRQFILE") == ""
+            assert primary_hdu.header.get("PWM_VAL") == ""
+
+            # ----------------------------------------------------------------------- #
+            # In the e-Callisto FITS files, the values assumed by the world coordinate
+            # system keywords don't appear to be consistent with the data in the binary
+            # table extension or the spectrogram. We prioritise making them consistent
+            # with e-Callisto, rather than the FITS standard. Values may be hardcoded and
+            # inconsistent with the data.
+            # ----------------------------------------------------------------------- #
+            # This appears to be the elapsed time from midnight on DATE-OBS.
+            assert primary_hdu.header.get("CRVAL1") == 3600
+            assert primary_hdu.header.get("CRPIX1") == 0
+            assert primary_hdu.header.get("CTYPE1") == "Time [UT]"
+            # All e-Calliso files inspected appear to hold here the time resolution (as opposed to CDELT2, which does not
+            # hold the frequency resolution).
+            assert np.isclose(primary_hdu.header.get("CDELT1"), 0.2)
+
+            # All e-Calliso files inspected held a fixed value of 200.
+            assert primary_hdu.header.get("CRVAL2") == 200
+            assert primary_hdu.header.get("CRPIX2") == 0
+            assert primary_hdu.header.get("CRTYPE2") == "Frequency [MHz]"
+            assert primary_hdu.header.get("CDELT2") == -1
+
+            # Secondly, check the keywords in the binary table extension.
+            bintable_hdu: astropy.io.fits.BinTableHDU = hdulist[1]
+
+            # ----------------------------------------------- #
+            # Conformal keywords that assume conformal values.
+            # ----------------------------------------------- #
+            assert bintable_hdu.header.get("XTENSION") == "BINTABLE"
+            assert bintable_hdu.header.get("BITPIX") == 8
+            assert bintable_hdu.header.get("NAXIS") == 2
+            assert bintable_hdu.header.get("PCOUNT") == 0
+            assert bintable_hdu.header.get("GCOUNT") == 1
+            assert bintable_hdu.header.get("TFIELDS") == 2
+            assert bintable_hdu.header.get("TTYPE1") == "TIME"
+            assert bintable_hdu.header.get("TTYPE2") == "FREQUENCY"
+            assert bintable_hdu.header.get("TSCAL1") == 1
+            assert bintable_hdu.header.get("TSCAL2") == 1
+            assert bintable_hdu.header.get("TZERO1") == 0
+            assert bintable_hdu.header.get("TZERO2") == 0
+            assert bintable_hdu.header.get("NAXIS1") == 4 * 8 + 6 * 8
+            assert bintable_hdu.header.get("NAXIS2") == 1
+
+            # ----------------------------------------------------------------------- #
+            # Conformal keywords that do not assume conformal values.
+            # ----------------------------------------------------------------------- #
+            # The .3 are e-Callisto conventions.
+            assert bintable_hdu.header.get("TFORM1") == "6D8.3"
+            assert bintable_hdu.header.get("TFORM2") == "4D8.3"

--- a/backend/tests/unit/core/test_batches.py
+++ b/backend/tests/unit/core/test_batches.py
@@ -547,7 +547,7 @@ class TestCallistoBatch:
         self,
     ) -> None:
         """Check that large values don't overflow when they're transformed to CALLISTO digits."""
-        # The big value and delta were found empircally.
+        # The big value and delta were found empirically.
         big_value, delta = 6958566400, 5e8
         just_under, just_over = big_value - delta, big_value + delta
         very_over = big_value * 2
@@ -607,7 +607,7 @@ class TestCallistoBatch:
         self,
     ) -> None:
         """Check that CALLISTO digits are preserved transforming to and from the linear scale."""
-        digits = np.arange(255, dtype=np.uint8)
+        digits = np.arange(256, dtype=np.uint8)
         assert np.array_equal(
             digits,
             spectre_server.core.batches.callisto_digits_from_linear(
@@ -685,7 +685,7 @@ class TestCallistoBatch:
             assert primary_hdu.header.get("BSCALE") == 1
             assert primary_hdu.header.get("DATAMIN") == 0
             assert primary_hdu.header.get("DATAMAX") == 35
-            # Not reccommended (the value should conform with the recommendations in the IAU Style Manual), but this is conformal.
+            # Not recommended (the value should conform with the recommendations in the IAU Style Manual), but this is conformal.
             assert primary_hdu.header.get("BUNIT") == "digits"
 
             # ----------------------------------------------------------------------- #
@@ -731,11 +731,11 @@ class TestCallistoBatch:
             assert primary_hdu.header.get("CRVAL1") == 3600
             assert primary_hdu.header.get("CRPIX1") == 0
             assert primary_hdu.header.get("CTYPE1") == "Time [UT]"
-            # All e-Calliso files inspected appear to hold here the time resolution (as opposed to CDELT2, which does not
+            # All e-Callisto files inspected appear to hold here the time resolution (as opposed to CDELT2, which does not
             # hold the frequency resolution).
             assert np.isclose(primary_hdu.header.get("CDELT1"), 0.2)
 
-            # All e-Calliso files inspected held a fixed value of 200.
+            # All e-Callisto files inspected held a fixed value of 200.
             assert primary_hdu.header.get("CRVAL2") == 200
             assert primary_hdu.header.get("CRPIX2") == 0
             assert primary_hdu.header.get("CRTYPE2") == "Frequency [MHz]"

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install .
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="4.0.0-alpha" \
+      version="4.1.0-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 
@@ -57,7 +57,7 @@ USER appuser
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="4.0.0-alpha" \
+      version="4.1.0-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-cli"
-version = "4.0.0-alpha"
+version = "4.1.0-alpha"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jimmy@spectregrams.org" },
 ]

--- a/cli/src/spectre_cli/__init__.py
+++ b/cli/src/spectre_cli/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "4.0.0-alpha"
+__version__ = "4.1.0-alpha"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   spectre-server:
     container_name: spectre-server
-    image: spectregrams/spectre-server:4.0.0-alpha
+    image: spectregrams/spectre-server:4.1.0-alpha
     environment:
       - SPECTRE_GID=${SPECTRE_GID}
       - SPECTRE_BIND_HOST=${SPECTRE_BIND_HOST}
@@ -20,7 +20,7 @@ services:
 
   spectre-cli:
     container_name: spectre-cli
-    image: spectregrams/spectre-cli:4.0.0-alpha
+    image: spectregrams/spectre-cli:4.1.0-alpha
     environment:
       - SPECTRE_SERVER_HOST=${SPECTRE_SERVER_HOST}
       - SPECTRE_SERVER_PORT=${SPECTRE_SERVER_PORT}


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
A new operating mode has been added to the `rx888mk2` so it can operate as a receiver for the [e-Callisto network](https://www.e-callisto.org/). In this mode:

- DFTs are applied to the stream of I/Q samples.
- The resulting DFT amplitudes are converted to equivalent CALLISTO receiver digits using a linear calibration.
- The spectrogram data is written to disk as FITS files that are compatible with those from the network.

The generated FITS files are suitable for publication to [Astrodoncel](https://astrodoncel.uah.es/) and, more generally, are intended to be compatible with any [Callisto software](https://www.e-callisto.org/Software/Callisto-Software.html).

## Issue link
<!-- Add the link to the related issue(s) -->
[issue-221](https://github.com/spectregrams/spectre/issues/221)

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [X] My changes are covered by unit tests
- [X] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
> n/a
