### PR TITLE
feat: issue-259 Optionally rename and compress when exporting data files

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -445,7 +445,7 @@ COPY gunicorn.conf.py /opt/spectre_server/
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="4.1.0-alpha" \
+      version="4.2.0-alpha" \
       description="Docker image for running the `spectre-server`." \
       license="GPL-3.0-or-later"
 
@@ -530,7 +530,7 @@ CMD ["/app/cmd.sh"]
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="4.1.0-alpha" \
+      version="4.2.0-alpha" \
       description="Docker image for  developing the `spectre-server`." \
       license="GPL-3.0-or-later"
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-server"
-version = "4.1.0-alpha"
+version = "4.2.0-alpha"
 authors = [
   { name = "Jimmy Fitzpatrick", email = "jimmy@spectregrams.org" }
 ]

--- a/backend/src/spectre_server/__init__.py
+++ b/backend/src/spectre_server/__init__.py
@@ -2,6 +2,6 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "4.1.0-alpha"
+__version__ = "4.2.0-alpha"
 
 __all__ = ["core", "routes", "services"]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install .
 FROM base AS runtime
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="4.1.0-alpha" \
+      version="4.2.0-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 
@@ -57,7 +57,7 @@ USER appuser
 FROM base AS development
 
 LABEL maintainer="Jimmy Fitzpatrick <jimmy@spectregrams.org>" \
-      version="4.1.0-alpha" \
+      version="4.2.0-alpha" \
       description="Docker image for running the `spectre-cli`." \
       license="GPL-3.0-or-later"
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectre-cli"
-version = "4.1.0-alpha"
+version = "4.2.0-alpha"
 maintainers = [
   { name="Jimmy Fitzpatrick", email="jimmy@spectregrams.org" },
 ]

--- a/cli/src/spectre_cli/__init__.py
+++ b/cli/src/spectre_cli/__init__.py
@@ -2,4 +2,4 @@
 # This file is part of SPECTRE
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-__version__ = "4.1.0-alpha"
+__version__ = "4.2.0-alpha"

--- a/cli/src/spectre_cli/__main__.py
+++ b/cli/src/spectre_cli/__main__.py
@@ -11,7 +11,6 @@ from spectre_cli.commands.update import update_typer
 from spectre_cli.commands.test import test_typer
 from spectre_cli.commands.record import record_typer
 
-
 app = typer.Typer(
     help="Spectre: Process, Explore and Capture Transient Radio Emissions"
 )

--- a/cli/src/spectre_cli/commands/delete.py
+++ b/cli/src/spectre_cli/commands/delete.py
@@ -12,7 +12,6 @@ from ._secho_resources import (
     secho_existing_resources,
 )
 
-
 delete_typer = typer.Typer(help="Delete resources.")
 
 

--- a/cli/src/spectre_cli/commands/get.py
+++ b/cli/src/spectre_cli/commands/get.py
@@ -19,7 +19,7 @@ from ._secho_resources import (
 _CALLISTO_FOCUS_CODE = "04"
 
 
-class RenamePolicy(str, enum.Enum):
+class _RenamePolicy(str, enum.Enum):
     spectre = "spectre"
     callisto = "callisto"
 
@@ -34,8 +34,8 @@ def __parse_spectre_file_name(file_name: str) -> tuple[datetime.datetime, str, s
         )
     except ValueError:
         typer.secho(
-            f"Error: Could not parse the file name '{file_name}'. Expected the form "
-            "'<datetime>_<tag>.<extension>', with an ISO 8601 formatted datetime.",
+            f"Error: Could not parse the file name '{file_name}'. The datetime is not "
+            "ISO 8601 compliant.",
             fg="yellow",
         )
         raise typer.Exit(1)
@@ -179,15 +179,15 @@ def files(
         "--export",
         help="Bulk download files to your local filesystem inside this directory.",
     ),
-    rename: RenamePolicy = typer.Option(
-        RenamePolicy.spectre,
+    rename: _RenamePolicy = typer.Option(
+        _RenamePolicy.spectre,
         "--rename",
         help="Rename files on export according to this policy. Ignored if '--export' is not provided.",
     ),
     compress: bool = typer.Option(
         False,
         "--compress",
-        help="Compress files on export using gzip, appending the '.gz' extension. Ignored if '--export' is not provided.",
+        help="Compress files on export using gzip. Ignored if '--export' is not provided.",
     ),
 ) -> None:
     params = {
@@ -206,7 +206,7 @@ def files(
 
     if export is None:
         secho_existing_resources(endpoints)
-    elif rename == RenamePolicy.callisto:
+    elif rename == _RenamePolicy.callisto:
         __download_callisto_resources(endpoints, export, compress)
     else:
         __download_resources(endpoints, export, compress)

--- a/cli/src/spectre_cli/commands/get.py
+++ b/cli/src/spectre_cli/commands/get.py
@@ -48,15 +48,6 @@ def __get_callisto_instrume(tag: str) -> str:
     jsend_dict = safe_request(f"spectre-data/configs/{file_name}/raw", "GET")
     config = jsend_dict["data"]
 
-    receiver_mode = config["receiver_mode"]
-    if receiver_mode != RenamePolicy.callisto.value:
-        typer.secho(
-            f"Error: The '{RenamePolicy.callisto.value}' rename policy requires the receiver mode "
-            f"'{RenamePolicy.callisto.value}', but the config with tag '{tag}' has mode '{receiver_mode}'.",
-            fg="yellow",
-        )
-        raise typer.Exit(1)
-
     instrume = config["parameters"].get("instrume")
     if instrume is None:
         typer.secho(
@@ -101,12 +92,17 @@ def __download_resources(
 def __download_callisto_resources(
     endpoints: list[str], directory: str, compress: bool = False
 ) -> None:
-    os.makedirs(directory, exist_ok=True)
+    # First, check that data files for all tags are _able_ to be renamed under this policy.
+    # Notably, they require the parameter `instrume` in the corresponding config.
     instrume_by_tag: dict[str, str] = {}
     for endpoint in endpoints:
         _, tag, _ = __parse_spectre_file_name(os.path.basename(endpoint))
         if tag not in instrume_by_tag:
             instrume_by_tag[tag] = __get_callisto_instrume(tag)
+
+    os.makedirs(directory, exist_ok=True)
+    for endpoint in endpoints:
+        _, tag, _ = __parse_spectre_file_name(os.path.basename(endpoint))
         file_name = __get_callisto_file_name(endpoint, instrume_by_tag[tag])
         __download_resource(endpoint, directory, file_name, compress)
 

--- a/cli/src/spectre_cli/commands/get.py
+++ b/cli/src/spectre_cli/commands/get.py
@@ -67,39 +67,48 @@ def __get_callisto_instrume(tag: str) -> str:
     return instrume
 
 
-def __download_resource(endpoint: str, directory: str) -> None:
-    file_path = os.path.join(directory, os.path.basename(endpoint))
-    response = requests.get(endpoint)
-    with open(file_path, "wb") as file:
-        file.write(response.content)
-
-
-def __download_callisto_resource(endpoint: str, directory: str, instrume: str) -> None:
+def __get_callisto_file_name(endpoint: str, instrume: str) -> str:
     datetime_value, _, extension = __parse_spectre_file_name(os.path.basename(endpoint))
-    file_name = (
+    return (
         f"{instrume}_{datetime_value.strftime('%Y%m%d_%H%M%S')}_"
-        f"{_CALLISTO_FOCUS_CODE}.{extension}.gz"
+        f"{_CALLISTO_FOCUS_CODE}.{extension}"
     )
+
+
+def __download_resource(
+    endpoint: str, directory: str, file_name: str, compress: bool = False
+) -> None:
+    if compress:
+        file_name += ".gz"
     file_path = os.path.join(directory, file_name)
     response = requests.get(endpoint)
-    with gzip.open(file_path, "wb") as file:
-        file.write(response.content)
+    if compress:
+        with gzip.open(file_path, "wb") as file:
+            file.write(response.content)
+    else:
+        with open(file_path, "wb") as file:
+            file.write(response.content)
 
 
-def __download_resources(endpoints: list[str], directory: str) -> None:
+def __download_resources(
+    endpoints: list[str], directory: str, compress: bool = False
+) -> None:
     os.makedirs(directory, exist_ok=True)
     for endpoint in endpoints:
-        __download_resource(endpoint, directory)
+        __download_resource(endpoint, directory, os.path.basename(endpoint), compress)
 
 
-def __download_callisto_resources(endpoints: list[str], directory: str) -> None:
+def __download_callisto_resources(
+    endpoints: list[str], directory: str, compress: bool = False
+) -> None:
     os.makedirs(directory, exist_ok=True)
     instrume_by_tag: dict[str, str] = {}
     for endpoint in endpoints:
         _, tag, _ = __parse_spectre_file_name(os.path.basename(endpoint))
         if tag not in instrume_by_tag:
             instrume_by_tag[tag] = __get_callisto_instrume(tag)
-        __download_callisto_resource(endpoint, directory, instrume_by_tag[tag])
+        file_name = __get_callisto_file_name(endpoint, instrume_by_tag[tag])
+        __download_resource(endpoint, directory, file_name, compress)
 
 
 get_typer = typer.Typer(help="Display one or many resources.")
@@ -179,6 +188,11 @@ def files(
         "--rename",
         help="Rename files on export according to this policy. Ignored if '--export' is not provided.",
     ),
+    compress: bool = typer.Option(
+        False,
+        "--compress",
+        help="Compress files on export using gzip, appending the '.gz' extension. Ignored if '--export' is not provided.",
+    ),
 ) -> None:
     params = {
         "extension": extensions,
@@ -197,9 +211,9 @@ def files(
     if export is None:
         secho_existing_resources(endpoints)
     elif rename == RenamePolicy.callisto:
-        __download_callisto_resources(endpoints, export)
+        __download_callisto_resources(endpoints, export, compress)
     else:
-        __download_resources(endpoints, export)
+        __download_resources(endpoints, export, compress)
 
     raise typer.Exit()
 

--- a/cli/src/spectre_cli/commands/get.py
+++ b/cli/src/spectre_cli/commands/get.py
@@ -5,6 +5,9 @@
 import typer
 import os
 import requests
+import datetime
+import enum
+import gzip
 
 from ._utils import safe_request, get_config_file_name
 from ._secho_resources import (
@@ -12,6 +15,56 @@ from ._secho_resources import (
     secho_existing_resource,
     secho_existing_resources,
 )
+
+_CALLISTO_FOCUS_CODE = "04"
+
+
+class RenamePolicy(str, enum.Enum):
+    default = "default"
+    callisto = "callisto"
+
+
+def __parse_spectre_file_name(file_name: str) -> tuple[datetime.datetime, str, str]:
+    """Parse a Spectre file name of the form `<datetime>_<tag>.<extension>`."""
+    base_name, _, extension = file_name.rpartition(".")
+    datetime_string, _, tag = base_name.partition("_")
+    try:
+        datetime_value = datetime.datetime.fromisoformat(
+            datetime_string.replace("Z", "+00:00")
+        )
+    except ValueError:
+        typer.secho(
+            f"Error: Could not parse the file name '{file_name}'. Expected the form "
+            "'<datetime>_<tag>.<extension>', with an ISO 8601 formatted datetime.",
+            fg="yellow",
+        )
+        raise typer.Exit(1)
+    return datetime_value, tag, extension
+
+
+def __get_callisto_instrume(tag: str) -> str:
+    """Extract the `instrume` parameter from the config with the given tag."""
+    file_name = get_config_file_name(file_name=None, tag=tag)
+    jsend_dict = safe_request(f"spectre-data/configs/{file_name}/raw", "GET")
+    config = jsend_dict["data"]
+
+    receiver_mode = config["receiver_mode"]
+    if receiver_mode != RenamePolicy.callisto.value:
+        typer.secho(
+            f"Error: The '{RenamePolicy.callisto.value}' rename policy requires the receiver mode "
+            f"'{RenamePolicy.callisto.value}', but the config with tag '{tag}' has mode '{receiver_mode}'.",
+            fg="yellow",
+        )
+        raise typer.Exit(1)
+
+    instrume = config["parameters"].get("instrume")
+    if instrume is None:
+        typer.secho(
+            f"Error: The config with tag '{tag}' is missing the required parameter 'instrume'.",
+            fg="yellow",
+        )
+        raise typer.Exit(1)
+    return instrume
 
 
 def __download_resource(endpoint: str, directory: str) -> None:
@@ -21,10 +74,32 @@ def __download_resource(endpoint: str, directory: str) -> None:
         file.write(response.content)
 
 
+def __download_callisto_resource(endpoint: str, directory: str, instrume: str) -> None:
+    datetime_value, _, extension = __parse_spectre_file_name(os.path.basename(endpoint))
+    file_name = (
+        f"{instrume}_{datetime_value.strftime('%Y%m%d_%H%M%S')}_"
+        f"{_CALLISTO_FOCUS_CODE}.{extension}.gz"
+    )
+    file_path = os.path.join(directory, file_name)
+    response = requests.get(endpoint)
+    with gzip.open(file_path, "wb") as file:
+        file.write(response.content)
+
+
 def __download_resources(endpoints: list[str], directory: str) -> None:
     os.makedirs(directory, exist_ok=True)
     for endpoint in endpoints:
         __download_resource(endpoint, directory)
+
+
+def __download_callisto_resources(endpoints: list[str], directory: str) -> None:
+    os.makedirs(directory, exist_ok=True)
+    instrume_by_tag: dict[str, str] = {}
+    for endpoint in endpoints:
+        _, tag, _ = __parse_spectre_file_name(os.path.basename(endpoint))
+        if tag not in instrume_by_tag:
+            instrume_by_tag[tag] = __get_callisto_instrume(tag)
+        __download_callisto_resource(endpoint, directory, instrume_by_tag[tag])
 
 
 get_typer = typer.Typer(help="Display one or many resources.")
@@ -99,6 +174,11 @@ def files(
         "--export",
         help="Bulk download files to your local filesystem inside this directory.",
     ),
+    rename: RenamePolicy = typer.Option(
+        RenamePolicy.default,
+        "--rename",
+        help="Rename files on export according to this policy. Ignored if '--export' is not provided.",
+    ),
 ) -> None:
     params = {
         "extension": extensions,
@@ -116,6 +196,8 @@ def files(
 
     if export is None:
         secho_existing_resources(endpoints)
+    elif rename == RenamePolicy.callisto:
+        __download_callisto_resources(endpoints, export)
     else:
         __download_resources(endpoints, export)
 

--- a/cli/src/spectre_cli/commands/get.py
+++ b/cli/src/spectre_cli/commands/get.py
@@ -20,7 +20,7 @@ _CALLISTO_FOCUS_CODE = "04"
 
 
 class RenamePolicy(str, enum.Enum):
-    default = "default"
+    spectre = "spectre"
     callisto = "callisto"
 
 
@@ -184,7 +184,7 @@ def files(
         help="Bulk download files to your local filesystem inside this directory.",
     ),
     rename: RenamePolicy = typer.Option(
-        RenamePolicy.default,
+        RenamePolicy.spectre,
         "--rename",
         help="Rename files on export according to this policy. Ignored if '--export' is not provided.",
     ),

--- a/cli/src/spectre_cli/commands/record.py
+++ b/cli/src/spectre_cli/commands/record.py
@@ -6,7 +6,6 @@ import typer
 
 from ._utils import safe_request, spinner
 
-
 record_typer = typer.Typer(help="Start recording data.")
 
 _DEFAULT_MAX_RESTARTS = 5

--- a/cli/src/spectre_cli/commands/update.py
+++ b/cli/src/spectre_cli/commands/update.py
@@ -8,7 +8,6 @@ from typing import List
 from ._utils import safe_request, get_config_file_name
 from ._secho_resources import secho_new_resource
 
-
 update_typer = typer.Typer(help="Update resources.")
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   spectre-server:
     container_name: spectre-server
-    image: spectregrams/spectre-server:4.1.0-alpha
+    image: spectregrams/spectre-server:4.2.0-alpha
     environment:
       - SPECTRE_GID=${SPECTRE_GID}
       - SPECTRE_BIND_HOST=${SPECTRE_BIND_HOST}
@@ -20,7 +20,7 @@ services:
 
   spectre-cli:
     container_name: spectre-cli
-    image: spectregrams/spectre-cli:4.1.0-alpha
+    image: spectregrams/spectre-cli:4.2.0-alpha
     environment:
       - SPECTRE_SERVER_HOST=${SPECTRE_SERVER_HOST}
       - SPECTRE_SERVER_PORT=${SPECTRE_SERVER_PORT}


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
To improve compatibility with CALLISTO software, this PR introduces the capability to rename files when we export them from _Spectre_. This is required, because both programs use different naming conventions. To facilitate this, we have introduced an optional `--rename` flag to the `spectre get files` CLI command with two policies:

- `spectre`: As-is behaviour - no file renaming. Example exported file name: `2026-07-09T20:31:00.200846Z_foo.fits`.
- `callisto`: Conforms file names to CALLISTO file name conventions. We use `<INSTRUME>_<datetime>_04.<original_extension>`, where `<INSTRUME>` is the value assumed by the FITS keyword of the same name in the primary HDU; `<datetime>` is of the form `%Y%m%d_%H%M%S`; `<original extension>` is the original file extension of the file being exported; and `04` is a non-configurable CALLISTO focus code, indicating the CALLISTO node uses an SDR as a receiver. Example exported file name: `UK-GLASGOW_20260710_124506_04.fit.gz`

If the flag is not provided, the current behavior is preserved.

At the same time, we provide the capability to compress files on export using the gzip algorithm. This is controlled through the `--compress` boolean flag.

## Issue link
<!-- Add the link to the related issue(s) -->
[issue-259](https://github.com/spectregrams/spectre/issues/259)

## Checklist before merging
<!-- Cross each tickbox, where applicable -->

- [X] My commit history follows the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Each commit represents a single, coherent unit of work
- [ ] My changes are covered by unit tests
- [ ] Unit tests successfully run locally
- [X] I have formatted Python code with `black`
- [X] I have checked static type hinting with `mypy`
- [X] I have added/updated necessary documentation, if required
- [X] I have checked for and resolved any merge conflicts
- [X] I have performed a self-review of my code

## Additional notes
<!-- Any additional information that reviewers should know -->
Other unrelated files are changed in this PR too, but it's all whitespace introduced by `black`.
