### PR TITLE
feat: issue-255 Parameterise the depth of the `rx888mk2` receive ring buffer

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -354,7 +354,7 @@ ARG TARGETARCH
 # Use a custom fork with a patch providing support for the RX-888 MK II on the platform `linux/arm64`.
 # See PR: (https://github.com/ik1xpv/ExtIO_sddc/pull/246).
 # TODO: Buld ExtIO_sddc from an official branch.
-RUN git clone --depth 1 -b v0.0.5 https://github.com/spectregrams/ExtIO_sddc && \
+RUN git clone --depth 1 -b v0.0.6 https://github.com/spectregrams/ExtIO_sddc && \
     cd ExtIO_sddc && \
     mkdir build && \
     cd build && \

--- a/backend/src/spectre_server/core/fields/_fields.py
+++ b/backend/src/spectre_server/core/fields/_fields.py
@@ -292,6 +292,15 @@ class Field:
             gt=0,
         ),
     ]
+    buffers = typing.Annotated[
+        int,
+        pydantic.Field(
+            ...,
+            validate_default=True,
+            gt=0,
+            description="The number of receive buffers to allocate in the Soapy device.",
+        ),
+    ]
     wire_format = typing.Annotated[
         str,
         pydantic.Field(

--- a/backend/src/spectre_server/core/fields/_fields.py
+++ b/backend/src/spectre_server/core/fields/_fields.py
@@ -298,7 +298,7 @@ class Field:
             ...,
             validate_default=True,
             gt=0,
-            description="The number of receive buffers to allocate in the Soapy device.",
+            description="Depth of the receive ring buffer.",
         ),
     ]
     wire_format = typing.Annotated[

--- a/backend/src/spectre_server/core/flowgraphs/_rx888mk2.py
+++ b/backend/src/spectre_server/core/flowgraphs/_rx888mk2.py
@@ -28,6 +28,7 @@ class RX888MK2FixedCenterFrequencyModel(BaseModel):
     if_gain: spectre_server.core.fields.Field.if_gain = -24.583
     rf_gain: spectre_server.core.fields.Field.rf_gain = -31.5
     batch_size: spectre_server.core.fields.Field.batch_size = 3
+    buffers: spectre_server.core.fields.Field.buffers = 1024
     output_type: spectre_server.core.fields.Field.output_type = (
         spectre_server.core.fields.OutputType.FC32
     )
@@ -39,7 +40,7 @@ class RX888MK2FixedCenterFrequency(Base[RX888MK2FixedCenterFrequencyModel]):
         type = model.output_type
         nchan = 1
         dev_args = ""
-        stream_args = ""
+        stream_args = f"buffers={model.buffers}"
         tune_args = [""]
         settings = [""]
         self.soapy_rx888mk2_source = soapy.source(


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
At high sample rates, the `rx888mk2` receiver drops samples resulting in file timestamps lagging behind physical time. To mitigate this, allow the depth of the ring buffer to be configurable through the `buffers` parameter in configs.

## Issue link
<!-- Add the link to the related issue(s) -->
[issue-255](https://github.com/spectregrams/spectre/issues/255)

## Checklist before merging
<!-- CI enforces conventional commits, formatting, type-checking, and tests. These items require judgement: -->

- [X] Each commit represents a single, coherent unit of work
- [X] New behaviour is covered by new tests
- [X] Documentation is updated where required

## Additional notes
<!-- Any additional information that reviewers should know -->
> Unit tests were provided in [ExtIO_sddc](https://github.com/spectregrams/ExtIO_sddc), see [here](https://github.com/spectregrams/ExtIO_sddc/blob/v0.0.6/unittest/soapysddc_test.cpp#L27-L42).
